### PR TITLE
Allow users to toggle between full and cropped gripper view

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,3 @@
 [flake8]
 max-line-length = 120
+extend-ignore = E203,E701

--- a/config/configure_video_streams_params.yaml
+++ b/config/configure_video_streams_params.yaml
@@ -1,6 +1,6 @@
 {
   # Images published to /navigation_camera/image_raw
-  # Image size is 768 x 1024
+  # Image size is 1024 x 768
   "overhead": { "fixed": {
           # The mask contain params to make a circular mask over the image
           # Pass "mask": null to not create mask
@@ -36,7 +36,7 @@
         { "mask": null, "crop": null, "rotate": "ROTATE_90_CLOCKWISE" },
     },
   # Images published to /gripper_camera/cropped/image_raw
-  # Image size is 768 x 1024
+  # Default image size is 1024 x 768. D405 is 480 x 270
   "gripper": { "default": {
           # The mask contain params to make a circular mask over the image
           # Pass "mask": null to not create mask
@@ -59,14 +59,16 @@
           "rotate": null,
         } },
   # Images published to /gripper_camera/expanded/image_raw
-  # Image size is 768 x 1024
+  # Default image size is 1024 x 768. D405 is 480 x 270.
+  # Since the default camera is fisheye, it is already circular. So we don't
+  # expand it.
   "expandedGripper": { "default": {
           # The mask contain params to make a circular mask over the image
           # For the mask the be circumscribed, its width/height must be:
           # ((768**2) + (1024**2))**0.5
           # Pass "mask": null to not create mask
           "mask":
-            { "width": 1280, "height": 1280, "radius": null, "center": null },
+            { "width": 768, "height": 768, "radius": null, "center": null },
           # The crop contain params to crop the image
           # x_max - x_min = mask_width and y_max - y_min = mask_height
           # Pass "crop": null to not crop image

--- a/config/configure_video_streams_params.yaml
+++ b/config/configure_video_streams_params.yaml
@@ -13,7 +13,7 @@
           # The crop contain params to crop the image
           # x_max - x_min = mask_width and y_max - y_min = mask_height
           # Pass "crop": null to not crop image
-          "crop": { "x_min": 0, "x_max": 768, "y_min": 128, "y_max": 896 },
+          "crop": { "x_min": 128, "x_max": 896, "y_min": 0, "y_max": 768 },
           # Number of degrees to rotate video stream clockwise
           # Pass "rotate": null to not rotate
           "rotate": null,
@@ -35,7 +35,7 @@
       "default":
         { "mask": null, "crop": null, "rotate": "ROTATE_90_CLOCKWISE" },
     },
-  # Images published to /gripper_camera/image_raw
+  # Images published to /gripper_camera/cropped/image_raw
   # Image size is 768 x 1024
   "gripper": { "default": {
           # The mask contain params to make a circular mask over the image
@@ -45,7 +45,7 @@
           # The crop contain params to crop the image
           # x_max - x_min = mask_width and y_max - y_min = mask_height
           # Pass "crop": null to not crop image
-          "crop": { "x_min": 0, "x_max": 768, "y_min": 128, "y_max": 896 },
+          "crop": { "x_min": 128, "x_max": 896, "y_min": 0, "y_max": 768 },
           "rotate": null,
         }, "d405": {
           # The mask contain params to make a circular mask over the image
@@ -55,7 +55,7 @@
           # The crop contain params to crop the image
           # x_max - x_min = mask_width and y_max - y_min = mask_height
           # Pass "crop": null to not crop image
-          "crop": { "y_min": 125, "y_max": 395, "x_min": 0, "x_max": 270 },
+          "crop": { "y_min": 0, "y_max": 270, "x_min": 125, "x_max": 395 },
           "rotate": null,
         } },
 }

--- a/config/configure_video_streams_params.yaml
+++ b/config/configure_video_streams_params.yaml
@@ -58,4 +58,31 @@
           "crop": { "y_min": 0, "y_max": 270, "x_min": 125, "x_max": 395 },
           "rotate": null,
         } },
+  # Images published to /gripper_camera/expanded/image_raw
+  # Image size is 768 x 1024
+  "expandedGripper": { "default": {
+          # The mask contain params to make a circular mask over the image
+          # For the mask the be circumscribed, its width/height must be:
+          # ((768**2) + (1024**2))**0.5
+          # Pass "mask": null to not create mask
+          "mask":
+            { "width": 1280, "height": 1280, "radius": null, "center": null },
+          # The crop contain params to crop the image
+          # x_max - x_min = mask_width and y_max - y_min = mask_height
+          # Pass "crop": null to not crop image
+          "crop": { "x_min": 128, "x_max": 896, "y_min": 0, "y_max": 768 },
+          "rotate": null,
+        }, "d405": {
+          # The mask contain params to make a circular mask over the image.
+          # For the mask the be circumscribed, its width/height must be:
+          # ((480**2) + (270**2))**0.5
+          # Pass "mask": null to not create mask
+          "mask":
+            { "width": 550, "height": 550, "radius": null, "center": null },
+          # The crop contain params to crop the image
+          # x_max - x_min = mask_width and y_max - y_min = mask_height
+          # Pass "crop": null to not crop image
+          "crop": { "y_min": -140, "y_max": 410, "x_min": -35, "x_max": 515 },
+          "rotate": null,
+        } },
 }

--- a/launch/multi_camera.launch.py
+++ b/launch/multi_camera.launch.py
@@ -164,10 +164,6 @@ def generate_launch_description():
                 src="/gripper_camera/color/image_rect_raw",
                 dst="/gripper_camera/image_raw",
             ),
-            SetRemap(
-                src="/gripper_camera/color/image_rect_raw/compressed",
-                dst="/gripper_camera/image_raw/compressed",
-            ),
             IncludeLaunchDescription(
                 PythonLaunchDescriptionSource(
                     [

--- a/launch/multi_camera.launch.py
+++ b/launch/multi_camera.launch.py
@@ -164,6 +164,10 @@ def generate_launch_description():
                 src="/gripper_camera/color/image_rect_raw",
                 dst="/gripper_camera/image_raw",
             ),
+            SetRemap(
+                src="/gripper_camera/color/image_rect_raw/compressed",
+                dst="/gripper_camera/image_raw/compressed",
+            ),
             IncludeLaunchDescription(
                 PythonLaunchDescriptionSource(
                     [

--- a/src/pages/operator/tsx/layout_components/CameraView.tsx
+++ b/src/pages/operator/tsx/layout_components/CameraView.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import {
   className,
+  expandedGripperProps,
   gripperProps,
   navigationProps,
   realsenseProps,
@@ -94,7 +95,7 @@ export const CameraView = (props: CustomizableComponentProps) => {
     : definition.children && definition.children.length > 0
       ? definition.children[0]
       : undefined;
-  const videoAspectRatio = getVideoAspectRatio(definition);
+  const videoAspectRatio = getVideoAspectRatio(definition, expandedGripperView);
   const overlay = createOverlay(
     overlayDefinition,
     props.path,
@@ -456,9 +457,15 @@ const SelectContexMenu = (props: SelectContexMenuProps) => {
  * @param definition definition of the video stream
  * @returns aspect ratio of the video stream
  */
-function getVideoAspectRatio(definition: CameraViewDefinition): number {
+function getVideoAspectRatio(
+  definition: CameraViewDefinition,
+  expandedGripperView: boolean,
+): number {
   switch (definition.id) {
     case CameraViewId.gripper:
+      if (expandedGripperView) {
+        return expandedGripperProps.width / expandedGripperProps.height;
+      }
       return gripperProps.width / gripperProps.height;
     case CameraViewId.overhead:
       return navigationProps.width / navigationProps.height;

--- a/src/pages/operator/tsx/layout_components/CameraView.tsx
+++ b/src/pages/operator/tsx/layout_components/CameraView.tsx
@@ -55,7 +55,10 @@ export const CameraView = (props: CustomizableComponentProps) => {
   const videoRef = React.useRef<HTMLVideoElement>(null);
   // X and Y position of the cursor when user clicks on the video
   const [clickXY, setClickXY] = React.useState<[number, number] | null>(null);
-  const definition = props.definition as CameraViewDefinition;
+  const definition = React.useMemo(
+    () => props.definition as CameraViewDefinition,
+    [props.definition],
+  );
   if (!definition.children)
     console.warn(
       `Video stream definition at ${props.path} should have a 'children' property.`,
@@ -82,7 +85,7 @@ export const CameraView = (props: CustomizableComponentProps) => {
         props.sharedState.remoteStreams,
         expandedGripperView,
       ),
-    [expandedGripperView],
+    [definition, expandedGripperView],
   );
 
   React.useEffect(() => {

--- a/src/pages/operator/tsx/layout_components/CameraView.tsx
+++ b/src/pages/operator/tsx/layout_components/CameraView.tsx
@@ -636,6 +636,7 @@ const UnderVideoButtons = (props: {
       buttons = (
         <UnderGripperButtons
           definition={props.definition}
+          betaTeleopKit={props.betaTeleopKit}
           setExpandedGripperView={props.setExpandedGripperView}
         />
       );
@@ -822,6 +823,7 @@ const UnderRealsenseButtons = (props: {
  */
 const UnderGripperButtons = (props: {
   definition: GripperVideoStreamDef;
+  betaTeleopKit: boolean;
   setExpandedGripperView: (expanded: boolean) => void;
 }) => {
   const [rerender, setRerender] = React.useState<boolean>(false);
@@ -836,20 +838,24 @@ const UnderGripperButtons = (props: {
             .onClick!();
         }}
       />
-      <CheckToggleButton
-        checked={props.definition.expandedGripperView || false}
-        onClick={() => {
-          if (!props.definition.expandedGripperView) {
-            props.setExpandedGripperView(true);
-            props.definition.expandedGripperView = true;
-          } else {
-            props.setExpandedGripperView(false);
-            props.definition.expandedGripperView = false;
-          }
-          setRerender(!rerender);
-        }}
-        label="Expanded Gripper View"
-      />
+      {props.betaTeleopKit ? (
+        <></>
+      ) : (
+        <CheckToggleButton
+          checked={props.definition.expandedGripperView || false}
+          onClick={() => {
+            if (!props.definition.expandedGripperView) {
+              props.setExpandedGripperView(true);
+              props.definition.expandedGripperView = true;
+            } else {
+              props.setExpandedGripperView(false);
+              props.definition.expandedGripperView = false;
+            }
+            setRerender(!rerender);
+          }}
+          label="Expanded Gripper View"
+        />
+      )}
     </React.Fragment>
   );
 };

--- a/src/pages/operator/tsx/utils/component_definitions.tsx
+++ b/src/pages/operator/tsx/utils/component_definitions.tsx
@@ -131,7 +131,12 @@ export type CameraViewDefinition = ParentComponentDefinition & {
  * simultaneously, any change to this definition for one view will impact
  * all views.
  */
-export type GripperVideoStreamDef = CameraViewDefinition;
+export type GripperVideoStreamDef = CameraViewDefinition & {
+  /**
+   * Whether to display the expanded gripper view or the default one
+   */
+  expandedGripperView?: boolean;
+};
 
 /**
  * Definition for the fixed overhead stream component

--- a/src/pages/robot/tsx/index.tsx
+++ b/src/pages/robot/tsx/index.tsx
@@ -71,7 +71,7 @@ robot.connect().then(() => {
   gripperStream.start();
 
   robot.subscribeToVideo({
-    topicName: "/gripper_camera/image_raw/compressed",
+    topicName: "/gripper_camera/image_raw/expanded/compressed",
     callback: expandedGripperStream.updateImage,
   });
   expandedGripperStream.start();

--- a/src/pages/robot/tsx/index.tsx
+++ b/src/pages/robot/tsx/index.tsx
@@ -7,6 +7,7 @@ import {
   navigationProps,
   realsenseProps,
   gripperProps,
+  expandedGripperProps,
   WebRTCMessage,
   ValidJointStateDict,
   ValidJointStateMessage,
@@ -39,6 +40,7 @@ export let connection: WebRTCConnection;
 export let navigationStream = new VideoStream(navigationProps);
 export let realsenseStream = new VideoStream(realsenseProps);
 export let gripperStream = new VideoStream(gripperProps);
+export let expandedGripperStream = new VideoStream(expandedGripperProps);
 // let occupancyGrid: ROSOccupancyGrid | undefined;
 
 connection = new WebRTCConnection({
@@ -68,6 +70,12 @@ robot.connect().then(() => {
   });
   gripperStream.start();
 
+  robot.subscribeToVideo({
+    topicName: "/gripper_camera/image_raw/compressed",
+    callback: expandedGripperStream.updateImage,
+  });
+  expandedGripperStream.start();
+
   robot.getOccupancyGrid();
   robot.getJointLimits();
 
@@ -93,6 +101,11 @@ function handleSessionStart() {
   stream
     .getTracks()
     .forEach((track) => connection.addTrack(track, stream, "gripper"));
+
+  stream = expandedGripperStream.outputVideoStream!;
+  stream
+    .getTracks()
+    .forEach((track) => connection.addTrack(track, stream, "expandedGripper"));
 
   connection.openDataChannels();
 }
@@ -265,6 +278,11 @@ const container = document.getElementById("root");
 const root = createRoot(container!); // createRoot(container!) if you use TypeScript
 root.render(
   <AllVideoStreamComponent
-    streams={[navigationStream, realsenseStream, gripperStream]}
+    streams={[
+      navigationStream,
+      realsenseStream,
+      gripperStream,
+      expandedGripperStream,
+    ]}
   />,
 );

--- a/src/shared/util.tsx
+++ b/src/shared/util.tsx
@@ -315,7 +315,7 @@ export const gripperProps = {
 
 export const expandedGripperProps = {
   width: 768, // 480
-  height: (768 * 270) / 420, // 270
+  height: 768, // 480
   scale: 1,
   fps: 6.0,
 };

--- a/src/shared/util.tsx
+++ b/src/shared/util.tsx
@@ -313,6 +313,13 @@ export const gripperProps = {
   fps: 6.0,
 };
 
+export const expandedGripperProps = {
+  width: 768, // 480
+  height: (768 * 270) / 420, // 270
+  scale: 1,
+  fps: 6.0,
+};
+
 export interface VideoProps {
   topicName: string;
   callback: (message: ROSCompressedImage) => void;


### PR DESCRIPTION
# Description

This PR, in service of #7 , allows users to expand the Gripper camera view.

This PR also addresses the following (small) bugs in the web interface:

1. Rotating the wrist sometimes introduced black space in the default gripper view, even though theoretically rotating a rectangle around an inscribed circle should never result in black space. (This was because we rotated the image before cropping it.)
2. `configure_video_streams` that did not swap x and y when indexing into OpenCV images. The first index of matrices is the row, which is the vertical dimension of images, e.g.,`img[row, col] = img[y, x]`. This bug did not impact functionality (since `x` and `y` were also swapped in the parameters), but did impact readability.

# Testing procedure

- [x] Toggle on/off the expanded gripper view, verify that everything renders as expected.
- [x] Rotate the wrist, verify that the expanded view rotates the background whereas the default view rotates the gripper.
- [x] Add a Dex Wrist button overlay on top of the gripper, verify that it renders correctly when the expanded gripper view is toggled on/off.
- [x] Add Realsense, overhead, and gripper camera views, verify the streams are correct.
- [x] Add the Realsense camera view with display buttons enabled, verify that "Depth sensing" works.
- [x] Test using the teleop interface to pick up an object, toggling the view as necessary/useful.
- [ ] Repeat the above tests on each of the following setups:
   - [ ] Stretch RE2 + no dex wrist w/ beta teleop kit (with this configuration, there should be no option for an expanded gripper view since it is fisheye and hence already circular)
   - [x] Stretch RE2 + dex wrist w/ beta teleop kit (with this configuration, there should be no option for an expanded gripper view since it is fisheye and hence already circular)
   - [x] Stretch RE2 + dex wrist w/ d405
   - [x] Stretch 3 + current teleop kit + dex wrist
- [x] Have a non-programmer use it, ensure it works for them.
    - (Their feedback was the rotating rectangle can make the user dizzy, but after seeing the version where the rectangle doesn't rotate but the background rotates, they preferred the rotating rectangle.) 

# Before opening a pull request

From the top-level of this repository, run:

- \[ \] `pre-commit run --all-files`

# To merge

- \[ \] `Squash & Merge`
