### PR TITLE
[Bugfix] Properly delete last Tab in a Panel

### DIFF
--- a/src/pages/operator/tsx/utils/layout_helpers.tsx
+++ b/src/pages/operator/tsx/utils/layout_helpers.tsx
@@ -139,6 +139,10 @@ function removeChildFromParent(
   let i = -2;
   let parentIdx: number;
   while (i >= -childSplitPath.length && parent.children.length === 0) {
+    // A tab is the only parent type that can have no children
+    if (parent.type === ComponentType.SingleTab) {
+      break;
+    }
     parentIdx = +childSplitPath.slice(i, i + 1);
     const grandparent = getParent(childSplitPath.slice(0, i + 1), layout);
     grandparent.children.splice(parentIdx, 1);

--- a/src/pages/operator/tsx/utils/layout_helpers.tsx
+++ b/src/pages/operator/tsx/utils/layout_helpers.tsx
@@ -133,20 +133,17 @@ function removeChildFromParent(
   childIdx: number,
   layout: LayoutDefinition,
 ) {
-  // If this is the last tab in a panel, then delete the entire panel
-  if (parent.type === ComponentType.Panel && parent.children.length === 1) {
-    const parentIdx = +childSplitPath.slice(-2, -1);
-    // note: since tabs cannot be nested, we can assume the layout is the
-    //       is the parent of the tabs component
-    layout.children.splice(parentIdx, 1);
-  }
+  // Remove the child from the parent
   parent.children.splice(childIdx, 1);
-  console.log(parent.type, parent.children.length);
-
-  if (parent.type == ComponentType.LayoutGrid && parent.children.length === 0) {
-    const parentIdx = +childSplitPath.slice(0, 1);
-    console.log(layout.children, childSplitPath, parentIdx);
-    layout.children.splice(parentIdx, 1);
+  // If it was the last child, also remove the parent. Continue iteratively.
+  let i = -2;
+  let parentIdx: number;
+  while (i >= -childSplitPath.length && parent.children.length === 0) {
+    parentIdx = +childSplitPath.slice(i, i + 1);
+    const grandparent = getParent(childSplitPath.slice(0, i + 1), layout);
+    grandparent.children.splice(parentIdx, 1);
+    parent = grandparent;
+    i -= 1;
   }
 }
 


### PR DESCRIPTION
# Description

Currently, there is a bug where if you click on the last tab of a panel and delete that, the entire web app crashes (white page). This bug does not occur when you click on the body of the panel itself, which is likely why it has eluded discovery. This PR fixes that and simplifies how we remove child elements from the web app.

# Testing procedure

- [x] **Recreate the bug**: On `master`, open the web app. Add a Panel called `test1`. Go into customize, and click on the **_tab_** (the blue strip on top of the panel with the name `test1` and click "delete"). Verify that the web app goes white.
- [x] **Verify the fix**: Pull this branch, repeat the above test, verify the web app doesn't go blank and the layout is correctly updated.
- [x] Test other cases:
    - [x] Start with the default layout (e.g., clear cookies).
    - [x] **Deleting a non-last tab in a panel**: Delete `Arm & Lift` and `Wrist & Gripper`.
    - [x] **Deleting the last tab in a panel that is not the last Panel in the Layout Grid**: Delete `Base`.
    - [x] **Deleting the last tab in a panel that is the last Panel in the Layout Grid**: Delete `Safety`.
    - [x] **Delete a non-last element within a tab**: Delete the gripper view.
    - [x] **Delete the non-last element within a tab**: Delete the nav cam view. Verify that the panel stays there with the tab, but the contents are empty.
    - [x] **Delete the last panel in the layout**: Delete the camera view panel.

# Before opening a pull request

From the top-level of this repository, run:

- \[x\] `pre-commit run --all-files`

# To merge

- \[ \] `Squash & Merge`
