### PR TITLE
Bugfix: Enable "Follow ..." feature when the tablet is attached

### DIFF
--- a/launch/web_interface.launch.py
+++ b/launch/web_interface.launch.py
@@ -422,7 +422,12 @@ def generate_launch_description():
         executable="configure_video_streams.py",
         output="screen",
         arguments=[LaunchConfiguration("params"), str(stretch_has_beta_teleop_kit)],
-        parameters=[{"has_beta_teleop_kit": stretch_has_beta_teleop_kit}],
+        parameters=[
+            {
+                "has_beta_teleop_kit": stretch_has_beta_teleop_kit,
+                "stretch_tool": stretch_tool,
+            }
+        ],
     )
     ld.add_action(configure_video_streams_node)
 

--- a/nodes/configure_video_streams.py
+++ b/nodes/configure_video_streams.py
@@ -33,7 +33,10 @@ class ConfigureVideoStreams(Node):
         with open(params_file, "r") as params:
             self.image_params = yaml.safe_load(params)
 
+        # These parameters are not used by this node. Rather, they are used by
+        # the web app to determine the robot's configuration.
         self.declare_parameter("has_beta_teleop_kit", rclpy.Parameter.Type.BOOL)
+        self.declare_parameter("stretch_tool", rclpy.Parameter.Type.STRING)
 
         self.tf_buffer = tf2_ros.Buffer(cache_time=Duration(seconds=12))
         self.tf2_listener = tf2_ros.TransformListener(self.tf_buffer, self)

--- a/src/pages/operator/tsx/MobileOperator.tsx
+++ b/src/pages/operator/tsx/MobileOperator.tsx
@@ -11,6 +11,7 @@ import { className, MoveBaseState, RemoteStream } from "shared/util";
 import {
   buttonFunctionProvider,
   hasBetaTeleopKit,
+  stretchTool,
   movementRecorderFunctionProvider,
   underMapFunctionProvider,
   underVideoFunctionProvider,
@@ -115,6 +116,7 @@ export const MobileOperator = (props: {
     buttonStateMap: buttonStateMap.current,
     hideLabels: false,
     hasBetaTeleopKit: hasBetaTeleopKit,
+    stretchTool: stretchTool,
   };
 
   function updateScreens() {

--- a/src/pages/operator/tsx/Operator.tsx
+++ b/src/pages/operator/tsx/Operator.tsx
@@ -14,6 +14,7 @@ import {
   buttonFunctionProvider,
   underMapFunctionProvider,
   hasBetaTeleopKit,
+  stretchTool,
 } from ".";
 import {
   ButtonPadButton,
@@ -219,6 +220,7 @@ export const Operator = (props: {
     buttonStateMap: buttonStateMap.current,
     hideLabels: !layout.current.displayLabels,
     hasBetaTeleopKit: hasBetaTeleopKit,
+    stretchTool: stretchTool,
   };
 
   /** Properties for the global options area of the sidebar */

--- a/src/pages/operator/tsx/index.tsx
+++ b/src/pages/operator/tsx/index.tsx
@@ -39,6 +39,7 @@ let remoteRobot: RemoteRobot;
 let connection: WebRTCConnection;
 let root: Root;
 export let hasBetaTeleopKit: boolean;
+export let stretchTool: string;
 export let occupancyGrid: ROSOccupancyGrid | undefined = undefined;
 export let storageHandler: StorageHandler;
 
@@ -153,6 +154,9 @@ function handleWebRTCMessage(message: WebRTCMessage | WebRTCMessage[]) {
     case "hasBetaTeleopKit":
       hasBetaTeleopKit = message.value;
       break;
+    case "stretchTool":
+      stretchTool = message.value;
+      break;
     case "occupancyGrid":
       if (!occupancyGrid) {
         occupancyGrid = message.message;
@@ -207,6 +211,7 @@ function configureRemoteRobot() {
   });
   occupancyGrid = undefined;
   remoteRobot.getHasBetaTeleopKit("getHasBetaTeleopKit");
+  remoteRobot.getStretchTool("getStretchTool");
   FunctionProvider.addRemoteRobot(remoteRobot);
   mapFunctionProvider = new MapFunctionProvider();
   remoteRobot.sensors.setFunctionProviderCallback(

--- a/src/pages/operator/tsx/layout_components/CameraView.tsx
+++ b/src/pages/operator/tsx/layout_components/CameraView.tsx
@@ -28,6 +28,7 @@ import { PredictiveDisplay } from "./PredictiveDisplay";
 import {
   buttonFunctionProvider,
   hasBetaTeleopKit,
+  stretchTool,
   underVideoFunctionProvider,
 } from "..";
 import {
@@ -720,7 +721,7 @@ const UnderAdjustableOverheadButtons = (props: {
             UnderVideoButton.FollowGripper,
           ).onCheck!(props.definition.followGripper);
         }}
-        label="Follow Gripper"
+        label={getFollowGripperLabel()}
       />
       <CheckToggleButton
         checked={props.definition.predictiveDisplay || false}
@@ -772,7 +773,7 @@ const UnderRealsenseButtons = (props: {
             UnderVideoButton.FollowGripper,
           ).onCheck!(props.definition.followGripper);
         }}
-        label="Follow Gripper"
+        label={getFollowGripperLabel()}
       />
       <CheckToggleButton
         checked={props.definition.depthSensing || false}
@@ -875,3 +876,19 @@ const CameraPerspectiveButton = (props: {
   ).onClick;
   return <button onClick={onClick}>{props.perspective}</button>;
 };
+
+function getFollowGripperLabel() {
+  if (stretchTool === "eoa_wrist_dw3_tool_tablet_12in") {
+    return "Follow Tablet";
+  } else if (
+    [
+      "eoa_wrist_dw3_tool_sg3",
+      "tool_stretch_dex_wrist",
+      "tool_stretch_gripper",
+    ].includes(stretchTool)
+  ) {
+    return "Follow Gripper";
+  } else {
+    return "Follow Wrist";
+  }
+}

--- a/src/pages/operator/tsx/layout_components/CustomizableComponent.tsx
+++ b/src/pages/operator/tsx/layout_components/CustomizableComponent.tsx
@@ -33,6 +33,8 @@ export type SharedState = {
   hideLabels?: boolean;
   /** Whether or not the beta teleop cameras are being used */
   hasBetaTeleopKit: boolean;
+  /** What tool is attached to the stretch gripper. */
+  stretchTool: string;
 };
 
 /** Properties for any of the customizable components: tabs, video streams, or

--- a/src/pages/robot/tsx/index.tsx
+++ b/src/pages/robot/tsx/index.tsx
@@ -24,7 +24,10 @@ import {
 } from "shared/util";
 import { AllVideoStreamComponent, VideoStream } from "./videostreams";
 import ROSLIB from "roslib";
-import { HasBetaTeleopKitMessage } from "../../../shared/util";
+import {
+  HasBetaTeleopKitMessage,
+  StretchToolMessage,
+} from "../../../shared/util";
 
 export const robot = new Robot({
   jointStateCallback: forwardJointStates,
@@ -34,6 +37,7 @@ export const robot = new Robot({
   amclPoseCallback: forwardAMCLPose,
   isRunStoppedCallback: forwardIsRunStopped,
   hasBetaTeleopKitCallback: forwardHasBetaTeleopKit,
+  stretchToolCallback: forwardStretchTool,
 });
 
 export let connection: WebRTCConnection;
@@ -142,6 +146,15 @@ function forwardHasBetaTeleopKit(value: boolean) {
     type: "hasBetaTeleopKit",
     value: value,
   } as HasBetaTeleopKitMessage);
+}
+
+function forwardStretchTool(value: string) {
+  if (!connection) throw "WebRTC connection undefined!";
+
+  connection.sendData({
+    type: "stretchTool",
+    value: value,
+  } as StretchToolMessage);
 }
 
 function forwardJointStates(
@@ -260,6 +273,8 @@ function handleMessage(message: WebRTCMessage) {
       break;
     case "getHasBetaTeleopKit":
       robot.getHasBetaTeleopKit();
+    case "getStretchTool":
+      robot.getStretchTool();
   }
 }
 

--- a/src/pages/robot/tsx/robot.tsx
+++ b/src/pages/robot/tsx/robot.tsx
@@ -53,9 +53,11 @@ export class Robot extends React.Component {
   private amclPoseCallback: (pose: ROSLIB.Transform) => void;
   private isRunStoppedCallback: (isRunStopped: boolean) => void;
   private hasBetaTeleopKitCallback: (value: boolean) => void;
+  private stretchToolCallback: (value: string) => void;
   private lookAtGripperInterval?: number; // ReturnType<typeof setInterval>
   private subscriptions: ROSLIB.Topic[] = [];
   private hasBetaTeleopKitParam: ROSLIB.Param;
+  private stretchToolParam: ROSLIB.Param;
 
   constructor(props: {
     jointStateCallback: (
@@ -69,6 +71,7 @@ export class Robot extends React.Component {
     amclPoseCallback: (pose: ROSLIB.Transform) => void;
     isRunStoppedCallback: (isRunStopped: boolean) => void;
     hasBetaTeleopKitCallback: (value: boolean) => void;
+    stretchToolCallback: (value: string) => void;
   }) {
     super(props);
     this.jointStateCallback = props.jointStateCallback;
@@ -78,6 +81,7 @@ export class Robot extends React.Component {
     this.amclPoseCallback = props.amclPoseCallback;
     this.isRunStoppedCallback = props.isRunStoppedCallback;
     this.hasBetaTeleopKitCallback = props.hasBetaTeleopKitCallback;
+    this.stretchToolCallback = props.stretchToolCallback;
   }
 
   async connect(): Promise<void> {
@@ -210,6 +214,18 @@ export class Robot extends React.Component {
     this.hasBetaTeleopKitParam.get((value: boolean) => {
       console.log("has beta teleop kit: ", value);
       if (this.hasBetaTeleopKitCallback) this.hasBetaTeleopKitCallback(value);
+    });
+  }
+
+  getStretchTool() {
+    this.stretchToolParam = new ROSLIB.Param({
+      ros: this.ros,
+      name: "/configure_video_streams:stretch_tool",
+    });
+
+    this.stretchToolParam.get((value: string) => {
+      console.log("stretch tool: ", value);
+      if (this.stretchToolCallback) this.stretchToolCallback(value);
     });
   }
 

--- a/src/pages/robot/tsx/robot.tsx
+++ b/src/pages/robot/tsx/robot.tsx
@@ -220,6 +220,7 @@ export class Robot extends React.Component {
 
   getStretchTool() {
     // NOTE: This information can also come from the /tool topic.
+    // However, we only need it once, so opt for a parameter.
     this.stretchToolParam = new ROSLIB.Param({
       ros: this.ros,
       name: "/configure_video_streams:stretch_tool",

--- a/src/pages/robot/tsx/robot.tsx
+++ b/src/pages/robot/tsx/robot.tsx
@@ -125,9 +125,6 @@ export class Robot extends React.Component {
     this.createRunStopService();
     this.createRobotFrameTFClient();
     this.createMapFrameTFClient();
-    this.subscribeToGripperFingerTF();
-    this.subscribeToTabletTF();
-    this.subscribeToWristYawTF();
     this.subscribeToHeadTiltTF();
     this.subscribeToMapTF();
 
@@ -230,6 +227,19 @@ export class Robot extends React.Component {
 
     this.stretchToolParam.get((value: string) => {
       console.log("stretch tool: ", value);
+      if (value === "eoa_wrist_dw3_tool_tablet_12in") {
+        this.subscribeToTabletTF();
+      } else if (
+        [
+          "eoa_wrist_dw3_tool_sg3",
+          "tool_stretch_dex_wrist",
+          "tool_stretch_gripper",
+        ].includes(value)
+      ) {
+        this.subscribeToGripperFingerTF();
+      } else {
+        this.subscribeToWristYawTF();
+      }
       if (this.stretchToolCallback) this.stretchToolCallback(value);
     });
   }

--- a/src/shared/commands.tsx
+++ b/src/shared/commands.tsx
@@ -16,7 +16,8 @@ export type cmd =
   | StopMoveBaseCommand
   | PlaybackPosesCommand
   | GetBatteryVoltageCommand
-  | GetHasBetaTeleopKit;
+  | GetHasBetaTeleopKit
+  | GetStretchTool;
 
 export interface VelocityCommand {
   stop: () => void;
@@ -73,6 +74,10 @@ export interface GetOccupancyGrid {
 
 export interface GetHasBetaTeleopKit {
   type: "getHasBetaTeleopKit";
+}
+
+export interface GetStretchTool {
+  type: "getStretchTool";
 }
 
 export interface MoveBaseCommand {

--- a/src/shared/remoterobot.tsx
+++ b/src/shared/remoterobot.tsx
@@ -21,7 +21,7 @@ import {
   ROSPose,
   waitUntil,
 } from "shared/util";
-import { GetHasBetaTeleopKit } from "./commands";
+import { GetHasBetaTeleopKit, GetStretchTool } from "./commands";
 
 export type robotMessageChannel = (message: cmd) => void;
 
@@ -175,6 +175,13 @@ export class RemoteRobot extends React.Component<{}, any> {
 
   getHasBetaTeleopKit(type: "getHasBetaTeleopKit") {
     let cmd: GetHasBetaTeleopKit = {
+      type: type,
+    };
+    this.robotChannel(cmd);
+  }
+
+  getStretchTool(type: "getStretchTool") {
+    let cmd: GetStretchTool = {
       type: type,
     };
     this.robotChannel(cmd);

--- a/src/shared/util.tsx
+++ b/src/shared/util.tsx
@@ -88,6 +88,7 @@ export type WebRTCMessage =
   | MoveBaseStateMessage
   | IsRunStoppedMessage
   | HasBetaTeleopKitMessage
+  | StretchToolMessage
   | cmd;
 
 interface StopTrajectoryMessage {
@@ -115,6 +116,11 @@ export interface IsRunStoppedMessage {
 export interface HasBetaTeleopKitMessage {
   type: "hasBetaTeleopKit";
   value: boolean;
+}
+
+export interface StretchToolMessage {
+  type: "stretchTool";
+  value: string;
 }
 
 export interface FollowJointTrajectoryActionResultMessage {


### PR DESCRIPTION
# Description

Currently, the "Follow Gripper" feature is broken when the tablet is attached, because it is looking for the `link_gripper_finger_left` TF frame, which doesn't exist.

This PR addresses that with the following:
1. Creates a ROS param that the web app has access to, which contains the tool. (Note that although there is a topic, `/tool`, that publishes this info, a ROS param reduces the number of messages that need to pass through RMW's wait set, particularly since this information is only needed once).
2. Changes the label of the button to "Follow Tablet" if the tool is the tablet, "Follow Gripper" if it is one of the grippers, else "Follow Wrist."
3. Change the TF poses it is following to be `link_DW3_tablet_12in`, `link_gripper_finger_left`, or `link_wrist_yaw` respectively, for each of the cases above.

# Testing procedure

- [x] Disconnect the Dex wrist and D405, attach the tablet, and run `stretch_configure_tool.py`. Choose the tablet.
- [x] Run the web interface, verify the button is "Follow Tablet" and it works as expected.
- [x] Re-run `stretch_configure_tool.py`, and choose nil.
- [x] Run the web interface, verify the button is "Follow Wrist" and it works as expected.
- [x] Re-connect the dex wrist and D405, and run `stretch_configure_tool.py`.
- [x] Run the web interface, verify the button is "Follow Gripper" and it works as expected.

# Before opening a pull request

From the top-level of this repository, run:

- \[x\] `pre-commit run --all-files`

# To merge

- \[ \] `Squash & Merge`
