### PR TITLE
Add Ability to Toggle Tablet Portrait/Landscape

### DIFF
--- a/src/pages/operator/tsx/Operator.tsx
+++ b/src/pages/operator/tsx/Operator.tsx
@@ -15,6 +15,7 @@ import {
   underMapFunctionProvider,
   hasBetaTeleopKit,
   stretchTool,
+  underVideoFunctionProvider,
 } from ".";
 import {
   ButtonPadButton,
@@ -76,6 +77,14 @@ export const Operator = (props: {
   }
   buttonFunctionProvider.setOperatorCallback(operatorCallback);
 
+  // Just used as a flag to force the operator to rerender when the tablet orientation
+  // changes.
+  const [tabletOrientationRerender, setTabletOrientationRerender] =
+    React.useState<boolean>(false);
+  underVideoFunctionProvider.setOperatorCallback((_) => {
+    setTabletOrientationRerender(!tabletOrientationRerender);
+  });
+
   function moveBaseStateCallback(state: MoveBaseState) {
     setMoveBaseState(state);
   }
@@ -96,6 +105,7 @@ export const Operator = (props: {
   function updateLayout() {
     console.log("update layout");
     setButtonStateMapRerender(!buttonStateMapRerender);
+    setTabletOrientationRerender(!tabletOrientationRerender);
   }
 
   /**

--- a/src/pages/operator/tsx/basic_components/AccordionSelect.tsx
+++ b/src/pages/operator/tsx/basic_components/AccordionSelect.tsx
@@ -27,10 +27,9 @@ export const AccordionSelect = <T extends string | JSX.Element>(props: {
           props.onChange(idx);
           toggleAccordion();
         }}
-        // We use dangerouslySetInnerHTML in case the option has an HTML
-        // character code e.g., &deg;
-        dangerouslySetInnerHTML={{ __html: option as string }}
-      ></div>
+      >
+        {option}
+      </div>
     );
   }
 

--- a/src/pages/operator/tsx/basic_components/AccordionSelect.tsx
+++ b/src/pages/operator/tsx/basic_components/AccordionSelect.tsx
@@ -27,9 +27,10 @@ export const AccordionSelect = <T extends string | JSX.Element>(props: {
           props.onChange(idx);
           toggleAccordion();
         }}
-      >
-        {option}
-      </div>
+        // We use dangerouslySetInnerHTML in case the option has an HTML
+        // character code e.g., &deg;
+        dangerouslySetInnerHTML={{ __html: option as string }}
+      ></div>
     );
   }
 

--- a/src/pages/operator/tsx/function_providers/ButtonFunctionProvider.tsx
+++ b/src/pages/operator/tsx/function_providers/ButtonFunctionProvider.tsx
@@ -109,6 +109,9 @@ export class ButtonFunctionProvider extends FunctionProvider {
     inJointLimit: ValidJointStateDict,
     inCollision: ValidJointStateDict,
   ) {
+    // For all the joints that are in collision, set their corresponding buttons
+    // either to collision (for the button corresponding to the direction the
+    // collision is in) or inactive (for the button corresponding to the other direction).
     Object.keys(inCollision).forEach((k: string) => {
       const key = k as ValidJoints;
       const [inCollisionNeg, inCollisionPos] = inCollision[key]!;
@@ -136,6 +139,9 @@ export class ButtonFunctionProvider extends FunctionProvider {
         );
     });
 
+    // For all the joints that are at their limit, set their corresponding buttons
+    // either to limit (for the button corresponding to the direction the joint
+    // limit is in) or inactive (for the button corresponding to the other direction).
     Object.keys(inJointLimit).forEach((k: string) => {
       const key = k as ValidJoints;
       const [inLimitNeg, inLimitPos] = inJointLimit[key]!;

--- a/src/pages/operator/tsx/function_providers/UnderVideoFunctionProvider.tsx
+++ b/src/pages/operator/tsx/function_providers/UnderVideoFunctionProvider.tsx
@@ -6,6 +6,8 @@ import {
   REALSENSE_FORWARD_POSE,
   REALSENSE_GRIPPER_POSE,
   STOW_WRIST,
+  WRIST_ROLL_ZERO,
+  WRIST_ROLL_NINETY,
 } from "../../../../shared/util";
 
 export enum UnderVideoButton {
@@ -19,6 +21,8 @@ export enum UnderVideoButton {
   ToggleArucoMarkers = "Toggle Aruco Markers",
   CenterWrist = "Center Wrist",
   StowWrist = "Stow Wrist",
+  WristRollZeroDeg = "Roll Wrist 0&deg;",
+  WristRollNinetyDeg = "Roll Wrist 90&deg;",
 }
 
 /** Array of different perspectives for the overhead camera */
@@ -39,6 +43,8 @@ export const realsenseButtons: UnderVideoButton[] = [
 export const wristButtons: UnderVideoButton[] = [
   UnderVideoButton.CenterWrist,
   UnderVideoButton.StowWrist,
+  UnderVideoButton.WristRollZeroDeg,
+  UnderVideoButton.WristRollNinetyDeg,
 ];
 /** Type to specify the different realsense camera perspectives */
 export type RealsenseButtons = (typeof realsenseButtons)[number];
@@ -112,6 +118,16 @@ export class UnderVideoFunctionProvider extends FunctionProvider {
       case UnderVideoButton.StowWrist:
         return {
           onClick: () => FunctionProvider.remoteRobot?.setRobotPose(STOW_WRIST),
+        };
+      case UnderVideoButton.WristRollZeroDeg:
+        return {
+          onClick: () =>
+            FunctionProvider.remoteRobot?.setRobotPose(WRIST_ROLL_ZERO),
+        };
+      case UnderVideoButton.WristRollNinetyDeg:
+        return {
+          onClick: () =>
+            FunctionProvider.remoteRobot?.setRobotPose(WRIST_ROLL_NINETY),
         };
       default:
         throw Error(

--- a/src/pages/operator/tsx/function_providers/UnderVideoFunctionProvider.tsx
+++ b/src/pages/operator/tsx/function_providers/UnderVideoFunctionProvider.tsx
@@ -5,10 +5,14 @@ import {
   REALSENSE_BASE_POSE,
   REALSENSE_FORWARD_POSE,
   REALSENSE_GRIPPER_POSE,
-  STOW_WRIST,
-  WRIST_ROLL_ZERO,
-  WRIST_ROLL_NINETY,
+  RobotPose,
+  STOW_WRIST_GRIPPER,
+  STOW_WRIST_TABLET,
+  TabletOrientation,
+  TABLET_ORIENTATION_LANDSCAPE,
+  TABLET_ORIENTATION_PORTRAIT,
 } from "../../../../shared/util";
+import { stretchTool } from "..";
 
 export enum UnderVideoButton {
   DriveView = "Drive View",
@@ -21,8 +25,8 @@ export enum UnderVideoButton {
   ToggleArucoMarkers = "Toggle Aruco Markers",
   CenterWrist = "Center Wrist",
   StowWrist = "Stow Wrist",
-  WristRollZeroDeg = "Roll Wrist 0&deg;",
-  WristRollNinetyDeg = "Roll Wrist 90&deg;",
+  ToggleTabletOrientation = "Toggle Tablet Orientation",
+  GetTabletOrientation = "Get Tablet Orientation",
 }
 
 /** Array of different perspectives for the overhead camera */
@@ -43,8 +47,6 @@ export const realsenseButtons: UnderVideoButton[] = [
 export const wristButtons: UnderVideoButton[] = [
   UnderVideoButton.CenterWrist,
   UnderVideoButton.StowWrist,
-  UnderVideoButton.WristRollZeroDeg,
-  UnderVideoButton.WristRollNinetyDeg,
 ];
 /** Type to specify the different realsense camera perspectives */
 export type RealsenseButtons = (typeof realsenseButtons)[number];
@@ -52,14 +54,23 @@ export type RealsenseButtons = (typeof realsenseButtons)[number];
 export type UnderVideoButtonFunctions = {
   onClick?: () => void;
   onCheck?: (toggle: boolean) => void;
-  getMarkers?: () => string[];
+  get?: () => any;
   send?: (name: string) => void;
 };
 
 export class UnderVideoFunctionProvider extends FunctionProvider {
+  private tabletOrientation: TabletOrientation;
+  /**
+   * Callback function for when the tablet orientation changes
+   */
+  private operatorCallback?: (tabletOrientation: TabletOrientation) => void =
+    undefined;
+
   constructor() {
     super();
+    this.tabletOrientation = TabletOrientation.LANDSCAPE;
     this.provideFunctions = this.provideFunctions.bind(this);
+    this.jointStateCallback = this.jointStateCallback.bind(this);
   }
 
   public provideFunctions(button: UnderVideoButton): UnderVideoButtonFunctions {
@@ -116,23 +127,76 @@ export class UnderVideoFunctionProvider extends FunctionProvider {
             FunctionProvider.remoteRobot?.setRobotPose(CENTER_WRIST),
         };
       case UnderVideoButton.StowWrist:
+        if (stretchTool === "eoa_wrist_dw3_tool_tablet_12in") {
+          return {
+            onClick: () =>
+              FunctionProvider.remoteRobot?.setRobotPose(STOW_WRIST_TABLET),
+          };
+        } else {
+          return {
+            onClick: () =>
+              FunctionProvider.remoteRobot?.setRobotPose(STOW_WRIST_GRIPPER),
+          };
+        }
+      case UnderVideoButton.ToggleTabletOrientation:
         return {
-          onClick: () => FunctionProvider.remoteRobot?.setRobotPose(STOW_WRIST),
+          onCheck: (isPortrait: boolean) =>
+            FunctionProvider.remoteRobot?.setRobotPose(
+              isPortrait
+                ? TABLET_ORIENTATION_LANDSCAPE
+                : TABLET_ORIENTATION_PORTRAIT,
+            ),
         };
-      case UnderVideoButton.WristRollZeroDeg:
+      case UnderVideoButton.GetTabletOrientation:
         return {
-          onClick: () =>
-            FunctionProvider.remoteRobot?.setRobotPose(WRIST_ROLL_ZERO),
-        };
-      case UnderVideoButton.WristRollNinetyDeg:
-        return {
-          onClick: () =>
-            FunctionProvider.remoteRobot?.setRobotPose(WRIST_ROLL_NINETY),
+          get: () => {
+            return this.tabletOrientation;
+          },
         };
       default:
         throw Error(
           `Cannot get function for unknown UnderVideoButton ${button}`,
         );
     }
+  }
+
+  /**
+   * Callback for when a new joint state is received.
+   */
+  public jointStateCallback(robotPose: RobotPose) {
+    let prevTabletOrientation = this.tabletOrientation;
+    // Update the tablet orientation
+    let wristRoll = 0.0;
+    if (robotPose.joint_wrist_roll) {
+      wristRoll = robotPose.joint_wrist_roll;
+    }
+    let diff = Math.abs(wristRoll % Math.PI);
+    let isLandscape = false;
+    if (diff <= Math.PI / 4.0 || diff >= (3.0 * Math.PI) / 4.0) {
+      isLandscape = true;
+    }
+    if (isLandscape) {
+      this.tabletOrientation = TabletOrientation.LANDSCAPE;
+    } else {
+      this.tabletOrientation = TabletOrientation.PORTRAIT;
+    }
+    if (
+      this.operatorCallback &&
+      prevTabletOrientation !== this.tabletOrientation
+    ) {
+      this.operatorCallback(this.tabletOrientation);
+    }
+  }
+
+  /**
+   * Sets the local pointer to the operator's callback function, to be called
+   * whenever the tablet orientation changes.
+   *
+   * @param callback operator's callback function to update aruco navigation state
+   */
+  public setOperatorCallback(
+    callback: (tabeltOrientation: TabletOrientation) => void,
+  ) {
+    this.operatorCallback = callback;
   }
 }

--- a/src/pages/operator/tsx/index.tsx
+++ b/src/pages/operator/tsx/index.tsx
@@ -6,7 +6,9 @@ import {
   RemoteStream,
   RobotPose,
   ROSOccupancyGrid,
+  StretchTool,
   delay,
+  getStretchTool,
   waitUntil,
 } from "shared/util";
 import { RemoteRobot } from "shared/remoterobot";
@@ -39,7 +41,7 @@ let remoteRobot: RemoteRobot;
 let connection: WebRTCConnection;
 let root: Root;
 export let hasBetaTeleopKit: boolean;
-export let stretchTool: string;
+export let stretchTool: StretchTool;
 export let occupancyGrid: ROSOccupancyGrid | undefined = undefined;
 export let storageHandler: StorageHandler;
 
@@ -155,7 +157,7 @@ function handleWebRTCMessage(message: WebRTCMessage | WebRTCMessage[]) {
       hasBetaTeleopKit = message.value;
       break;
     case "stretchTool":
-      stretchTool = message.value;
+      stretchTool = getStretchTool(message.value);
       break;
     case "occupancyGrid":
       if (!occupancyGrid) {
@@ -216,6 +218,9 @@ function configureRemoteRobot() {
   mapFunctionProvider = new MapFunctionProvider();
   remoteRobot.sensors.setFunctionProviderCallback(
     buttonFunctionProvider.updateJointStates,
+  );
+  remoteRobot.sensors.setJointStateFunctionProviderCallback(
+    underVideoFunctionProvider.jointStateCallback,
   );
   remoteRobot.sensors.setBatteryFunctionProviderCallback(
     batteryVoltageFunctionProvider.updateVoltage,

--- a/src/pages/operator/tsx/layout_components/CustomizableComponent.tsx
+++ b/src/pages/operator/tsx/layout_components/CustomizableComponent.tsx
@@ -5,7 +5,7 @@ import {
 } from "../utils/component_definitions";
 import { DropZoneState } from "./DropZone";
 import { Panel } from "./Panel";
-import { RemoteStream } from "shared/util";
+import { RemoteStream, StretchTool } from "shared/util";
 import { ButtonPad } from "./ButtonPad";
 import { CameraView } from "./CameraView";
 import { PredictiveDisplay } from "./PredictiveDisplay";
@@ -34,7 +34,7 @@ export type SharedState = {
   /** Whether or not the beta teleop cameras are being used */
   hasBetaTeleopKit: boolean;
   /** What tool is attached to the stretch gripper. */
-  stretchTool: string;
+  stretchTool: StretchTool;
 };
 
 /** Properties for any of the customizable components: tabs, video streams, or

--- a/src/shared/remoterobot.tsx
+++ b/src/shared/remoterobot.tsx
@@ -216,6 +216,7 @@ class RobotSensors extends React.Component {
   ) => void;
   private batteryFunctionProviderCallback?: (voltage: number) => void;
   private runStopFunctionProviderCallback?: (enabled: boolean) => void;
+  private jointStateFunctionProviderCallback?: (robotPose: RobotPose) => void;
 
   constructor(props: {}) {
     super(props);
@@ -228,6 +229,8 @@ class RobotSensors extends React.Component {
       this.setBatteryFunctionProviderCallback.bind(this);
     this.setRunStopFunctionProviderCallback =
       this.setRunStopFunctionProviderCallback.bind(this);
+    this.setJointStateFunctionProviderCallback =
+      this.setJointStateFunctionProviderCallback.bind(this);
   }
 
   /**
@@ -281,9 +284,14 @@ class RobotSensors extends React.Component {
       }
     });
 
-    // Only callback when value has changed
+    // Call the callback when joint limits or in collition joints have changed.
     if (change && this.functionProviderCallback) {
       this.functionProviderCallback(jointValues, effortValues);
+    }
+
+    // Call the callback when a new joint state is received.
+    if (this.jointStateFunctionProviderCallback) {
+      this.jointStateFunctionProviderCallback(this.robotPose);
     }
   }
 
@@ -300,6 +308,18 @@ class RobotSensors extends React.Component {
     ) => void,
   ) {
     this.functionProviderCallback = callback;
+  }
+
+  /**
+   * Records a callback from the function provider. The callback is called
+   * whenever a new joint state is received.
+   *
+   * @param callback callback to function provider
+   */
+  setJointStateFunctionProviderCallback(
+    callback: (robotPose: RobotPose) => void,
+  ) {
+    this.jointStateFunctionProviderCallback = callback;
   }
 
   setBatteryVoltage(voltage: number) {

--- a/src/shared/util.tsx
+++ b/src/shared/util.tsx
@@ -52,6 +52,33 @@ export interface ROSJointState extends Message {
   velocity: [number];
 }
 
+export enum StretchTool {
+  GRIPPER = "gripper",
+  TABLET = "tablet",
+  UNKNOWN = "unknown",
+}
+
+export function getStretchTool(stretchTool: string) {
+  if (stretchTool === "eoa_wrist_dw3_tool_tablet_12in") {
+    return StretchTool.TABLET;
+  } else if (
+    [
+      "eoa_wrist_dw3_tool_sg3",
+      "tool_stretch_dex_wrist",
+      "tool_stretch_gripper",
+    ].includes(stretchTool)
+  ) {
+    return StretchTool.GRIPPER;
+  } else {
+    return StretchTool.UNKNOWN;
+  }
+}
+
+export enum TabletOrientation {
+  PORTRAIT = "portrait",
+  LANDSCAPE = "landscape",
+}
+
 export interface ROSBatteryState extends Message {
   voltage: number;
 }
@@ -233,10 +260,16 @@ export interface ROSOccupancyGrid {
   data: number[];
 }
 
-export const STOW_WRIST: RobotPose = {
+export const STOW_WRIST_GRIPPER: RobotPose = {
   joint_wrist_roll: 0.0,
   joint_wrist_pitch: -0.497,
   joint_wrist_yaw: 3.19579,
+};
+
+export const STOW_WRIST_TABLET: RobotPose = {
+  joint_wrist_roll: Math.PI / 2.0,
+  joint_wrist_pitch: 0.0,
+  joint_wrist_yaw: Math.PI / 2.0,
 };
 
 export const CENTER_WRIST: RobotPose = {
@@ -245,12 +278,12 @@ export const CENTER_WRIST: RobotPose = {
   joint_wrist_yaw: 0.0,
 };
 
-export const WRIST_ROLL_ZERO: RobotPose = {
+export const TABLET_ORIENTATION_LANDSCAPE: RobotPose = {
   joint_wrist_roll: 0.0,
 };
 
-export const WRIST_ROLL_NINETY: RobotPose = {
-  joint_wrist_roll: 1.57079632679,
+export const TABLET_ORIENTATION_PORTRAIT: RobotPose = {
+  joint_wrist_roll: Math.PI / 2.0,
 };
 
 export const REALSENSE_FORWARD_POSE: RobotPose = {

--- a/src/shared/util.tsx
+++ b/src/shared/util.tsx
@@ -245,6 +245,14 @@ export const CENTER_WRIST: RobotPose = {
   joint_wrist_yaw: 0.0,
 };
 
+export const WRIST_ROLL_ZERO: RobotPose = {
+  joint_wrist_roll: 0.0,
+};
+
+export const WRIST_ROLL_NINETY: RobotPose = {
+  joint_wrist_roll: 1.57079632679,
+};
+
 export const REALSENSE_FORWARD_POSE: RobotPose = {
   joint_head_pan: 0.075,
   joint_head_tilt: 0.0,


### PR DESCRIPTION
# Description

When the tablet is attached, it can be hard for the remote operator to:
(a) know whether the tablet is in portrait or landscape mode;
(b) move the tablet to portrait or landscape mode (exactly, without a few-degree offset).

This PR addresses that. Essentially, every time a new joint state is received by the operator interface, it computes the tablet orientation. It always displays a button below the gripper view, "Switch to ______ View", where ____ is either Portrait or Landscape, whichever is the opposite of the robot's current tablet orientation.

This PR also creates a tablet-specific stow configuration.

# Testing procedure

- [x] Switch the tool to the tablet by disconnecting the dex wrist and using `stretch_configure_tool.py`
- [x] Start the interface, verify it has the correct orientation for the tablet (by verifying that the button shows the opposite orientation).
- [x] Click the button, verify it toggles the orientation.
- [x] Click the button again, verify it toggles the orientation.
- [x] Use the button pad to roll the joint. Verify the button updates when the tablet is closer to the other orientation than its current one.
- [x] Move to another pitch and yaw. Verify that toggling it still works.
- [x] Stop the interface, and switch the tool to the Dex Wrist.
- [x] Launch the interface, and verify that the toggle tablet orientation button does not appear below the gripper camera.

# Future Work

It would be helpful to have similar "roll 90 degrees" actions for the gripper, but in that case there are more options than just portrait and landscape. For that case, we should put "roll clockwise/counter" buttons on the left/right of the gripper camera, similar to the head pan buttons, which rotates the wrist +/i 90 degrees, snapping to the nearest multiple of 90 degrees.

# Before opening a pull request

From the top-level of this repository, run:

- \[x\] `pre-commit run --all-files`

# To merge

- \[ \] `Squash & Merge`
