### PR TITLE
Adds a Gripper Depth Overlay

### DIFF
--- a/launch/multi_camera.launch.py
+++ b/launch/multi_camera.launch.py
@@ -1,146 +1,166 @@
+# Adapted from https://github.com/IntelRealSense/realsense-ros/tree/ros2-development/realsense2_camera/launch
+
 import os
 
+import yaml
 from ament_index_python.packages import get_package_share_directory
-from launch_ros.actions import Node, SetRemap
+from launch_ros.actions import Node
 
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument, GroupAction, IncludeLaunchDescription
-from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.actions import DeclareLaunchArgument, OpaqueFunction
 from launch.substitutions import LaunchConfiguration
 
 json_path = os.path.join(
     get_package_share_directory("stretch_core"), "config", "HighAccuracyPreset.json"
 )
-
 D435_RESOLUTION = "424x240x15"
 D405_RESOLUTION = "480x270x15"
 
-configurable_parameters = [
-    {"name": "camera_namespace1", "default": "", "description": "namespace for camera"},
-    {"name": "camera_name1", "default": "camera", "description": "camera unique name"},
-    {"name": "device_type1", "default": "d435", "description": "camera unique name"},
-    {
-        "name": "json_file_path1",
-        "default": json_path,
-        "description": "allows advanced configuration",
-    },
-    {
-        "name": "depth_module.depth_profile1",
-        "default": D435_RESOLUTION,
-        "description": "depth module profile",
-    },
-    {
-        "name": "depth_module.infra_profile1",
-        "default": D435_RESOLUTION,
-        "description": "depth module infrared profile",
-    },
-    {"name": "enable_depth1", "default": "true", "description": "enable depth stream"},
-    {
-        "name": "rgb_camera.color_profile1",
-        "default": D435_RESOLUTION,
-        "description": "color image width",
-    },
-    {"name": "enable_color1", "default": "true", "description": "enable color stream"},
-    {
-        "name": "enable_infra11",
-        "default": "true",
-        "description": "enable infra1 stream",
-    },
-    {
-        "name": "enable_infra21",
-        "default": "false",
-        "description": "enable infra2 stream",
-    },
-    {"name": "infra_rgb1", "default": "false", "description": "enable infra2 stream"},
-    {
-        "name": "enable_confidence1",
-        "default": "false",
-        "description": "enable depth stream",
-    },
-    {"name": "gyro_fps1", "default": "200", "description": "''"},
-    {"name": "accel_fps1", "default": "100", "description": "''"},
-    {"name": "enable_gyro1", "default": "true", "description": "''"},
-    {"name": "enable_accel1", "default": "true", "description": "''"},
-    {"name": "pointcloud.enable1", "default": "true", "description": ""},
-    {
-        "name": "pointcloud.stream_filter1",
-        "default": "2",
-        "description": "texture stream for pointcloud",
-    },
-    {
-        "name": "pointcloud.stream_index_filter1",
-        "default": "0",
-        "description": "texture stream index for pointcloud",
-    },
-    {"name": "enable_sync1", "default": "true", "description": "''"},
-    {"name": "align_depth.enable1", "default": "true", "description": "''"},
-    {"name": "initial_reset1", "default": "true", "description": "''"},
-    {"name": "allow_no_texture_points1", "default": "true", "description": "''"},
-    {"name": "camera_namespace2", "default": "", "description": "namespace for camera"},
-    {
-        "name": "camera_name2",
-        "default": "gripper_camera",
-        "description": "camera unique name",
-    },
-    {"name": "device_type2", "default": "d405", "description": "camera unique name"},
-    {
-        "name": "json_file_path2",
-        "default": json_path,
-        "description": "allows advanced configuration",
-    },
-    {
-        "name": "depth_module.depth_profile2",
-        "default": D405_RESOLUTION,
-        "description": "depth module profile",
-    },
-    {
-        "name": "depth_module.enable_auto_exposure2",
-        "default": "true",
-        "description": "enable/disable auto exposure for depth image",
-    },
-    {"name": "enable_depth2", "default": "true", "description": "enable depth stream"},
-    {
-        "name": "depth_module.color_profile2",
-        "default": D405_RESOLUTION,
-        "description": "color image width",
-    },
-    {"name": "enable_color2", "default": "true", "description": "enable color stream"},
-    {
-        "name": "enable_infra12",
-        "default": "false",
-        "description": "enable infra1 stream",
-    },
-    {
-        "name": "enable_infra22",
-        "default": "false",
-        "description": "enable infra2 stream",
-    },
-    {"name": "infra_rgb2", "default": "false", "description": "enable infra2 stream"},
-    {
-        "name": "enable_confidence2",
-        "default": "false",
-        "description": "enable depth stream",
-    },
-    {"name": "gyro_fps2", "default": "200", "description": "''"},
-    {"name": "accel_fps2", "default": "100", "description": "''"},
-    {"name": "enable_gyro2", "default": "true", "description": "''"},
-    {"name": "enable_accel2", "default": "true", "description": "''"},
-    {"name": "pointcloud.enable2", "default": "true", "description": ""},
-    {
-        "name": "pointcloud.stream_filter2",
-        "default": "2",
-        "description": "texture stream for pointcloud",
-    },
-    {
-        "name": "pointcloud.stream_index_filter2",
-        "default": "0",
-        "description": "texture stream index for pointcloud",
-    },
-    {"name": "enable_sync2", "default": "true", "description": "''"},
-    {"name": "align_depth.enable2", "default": "true", "description": "''"},
-    {"name": "initial_reset2", "default": "false", "description": "''"},
-    {"name": "allow_no_texture_points2", "default": "true", "description": "''"},
+# Starting with `realsense_ros` 4.55.1, the `.profile`` parameter is split by stream type.
+# Here, we keep both the old and new parameters for backwards compatibility.
+# https://github.com/IntelRealSense/realsense-ros/pull/3052
+# fmt: off
+base_configurable_parameters = [
+    {'name': 'camera_name',                  'default': 'camera', 'description': 'camera unique name'},
+    {'name': 'camera_namespace',             'default': '', 'description': 'namespace for camera'},
+    {'name': 'serial_no',                    'default': "''", 'description': 'choose device by serial number'},
+    {'name': 'usb_port_id',                  'default': "''", 'description': 'choose device by usb port id'},
+    {'name': 'device_type',                  'default': "''", 'description': 'choose device by type'},
+    {'name': 'config_file',                  'default': "''", 'description': 'yaml config file'},
+    {'name': 'json_file_path',               'default': "''", 'description': 'allows advanced configuration'},
+    {'name': 'initial_reset',                'default': 'false', 'description': "''"},
+    {'name': 'accelerate_gpu_with_glsl',     'default': "false", 'description': 'enable GPU acceleration with GLSL'},
+    {'name': 'rosbag_filename',              'default': "''", 'description': 'A realsense bagfile to run from as a device'},  # noqa: E501
+    {'name': 'log_level',                    'default': 'info', 'description': 'debug log level [DEBUG|INFO|WARN|ERROR|FATAL]'},  # noqa: E501
+    {'name': 'output',                       'default': 'screen', 'description': 'pipe node output [screen|log]'},
+    {'name': 'enable_color',                 'default': 'true', 'description': 'enable color stream'},
+    {'name': 'rgb_camera.profile',           'default': '0,0,0', 'description': 'color stream profile'},
+    {'name': 'rgb_camera.color_profile',     'default': '0,0,0', 'description': 'color stream profile'},
+    {'name': 'rgb_camera.color_format',      'default': 'RGB8', 'description': 'color stream format'},
+    {'name': 'rgb_camera.enable_auto_exposure', 'default': 'true', 'description': 'enable/disable auto exposure for color image'},  # noqa: E501
+    {'name': 'enable_depth',                 'default': 'true', 'description': 'enable depth stream'},
+    {'name': 'enable_infra',                 'default': 'false', 'description': 'enable infra0 stream'},
+    {'name': 'enable_infra1',                'default': 'false', 'description': 'enable infra1 stream'},
+    {'name': 'enable_infra2',                'default': 'false', 'description': 'enable infra2 stream'},
+    {'name': 'infra_rgb',                    'default': 'false', 'description': ''},
+    {'name': 'enable_confidence',            'default': 'false', 'description': ''},
+    {'name': 'depth_module.profile',         'default': '0,0,0', 'description': 'depth stream profile'},
+    {'name': 'depth_module.depth_profile',   'default': '0,0,0', 'description': 'depth stream profile'},
+    {'name': 'depth_module.depth_format',    'default': 'Z16', 'description': 'depth stream format'},
+    {'name': 'depth_module.infra_profile',   'default': '0,0,0', 'description': 'infra streams (0/1/2) profile'},
+    {'name': 'depth_module.infra_format',    'default': 'RGB8', 'description': 'infra0 stream format'},
+    {'name': 'depth_module.infra1_format',   'default': 'Y8', 'description': 'infra1 stream format'},
+    {'name': 'depth_module.infra2_format',   'default': 'Y8', 'description': 'infra2 stream format'},
+    {'name': 'depth_module.color_profile',   'default': '0,0,0', 'description': 'infra2 stream format'},
+    {'name': 'depth_module.exposure',        'default': '8500', 'description': 'Depth module manual exposure value'},
+    {'name': 'depth_module.gain',            'default': '16', 'description': 'Depth module manual gain value'},
+    {'name': 'depth_module.hdr_enabled',     'default': 'false', 'description': 'Depth module hdr enablement flag. Used for hdr_merge filter'},  # noqa: E501
+    {'name': 'depth_module.enable_auto_exposure', 'default': 'true', 'description': 'enable/disable auto exposure for depth image'},  # noqa: E501
+    {'name': 'depth_module.exposure.1',      'default': '7500', 'description': 'Depth module first exposure value. Used for hdr_merge filter'},  # noqa: E501
+    {'name': 'depth_module.gain.1',          'default': '16', 'description': 'Depth module first gain value. Used for hdr_merge filter'},  # noqa: E501
+    {'name': 'depth_module.exposure.2',      'default': '1', 'description': 'Depth module second exposure value. Used for hdr_merge filter'},  # noqa: E501
+    {'name': 'depth_module.gain.2',          'default': '16', 'description': 'Depth module second gain value. Used for hdr_merge filter'},  # noqa: E501
+    {'name': 'enable_sync',                  'default': 'false', 'description': "'enable sync mode'"},
+    {'name': 'enable_rgbd',                  'default': 'false', 'description': "'enable rgbd topic'"},
+    {'name': 'enable_gyro',                  'default': 'false', 'description': "'enable gyro stream'"},
+    {'name': 'enable_accel',                 'default': 'false', 'description': "'enable accel stream'"},
+    {'name': 'gyro_fps',                     'default': '0', 'description': "''"},
+    {'name': 'accel_fps',                    'default': '0', 'description': "''"},
+    {'name': 'unite_imu_method',             'default': "0", 'description': '[0-None, 1-copy, 2-linear_interpolation]'},
+    {'name': 'clip_distance',                'default': '-2.', 'description': "''"},
+    {'name': 'angular_velocity_cov',         'default': '0.01', 'description': "''"},
+    {'name': 'linear_accel_cov',             'default': '0.01', 'description': "''"},
+    {'name': 'diagnostics_period',           'default': '0.0', 'description': 'Rate of publishing diagnostics. 0=Disabled'},  # noqa: E501
+    {'name': 'publish_tf',                   'default': 'true', 'description': '[bool] enable/disable publishing static & dynamic TF'},  # noqa: E501
+    {'name': 'tf_publish_rate',              'default': '0.0', 'description': '[double] rate in Hz for publishing dynamic TF'},  # noqa: E501
+    {'name': 'pointcloud.enable',            'default': 'false', 'description': ''},
+    {'name': 'pointcloud.stream_filter',     'default': '2', 'description': 'texture stream for pointcloud'},
+    {'name': 'pointcloud.stream_index_filter', 'default': '0', 'description': 'texture stream index for pointcloud'},
+    {'name': 'pointcloud.ordered_pc',        'default': 'false', 'description': ''},
+    {'name': 'pointcloud.allow_no_texture_points', 'default': 'false', 'description': "''"},
+    {'name': 'align_depth.enable',           'default': 'false', 'description': 'enable align depth filter'},
+    {'name': 'colorizer.enable',             'default': 'false', 'description': 'enable colorizer filter'},
+    {'name': 'decimation_filter.enable',     'default': 'false', 'description': 'enable_decimation_filter'},
+    {'name': 'spatial_filter.enable',        'default': 'false', 'description': 'enable_spatial_filter'},
+    {'name': 'temporal_filter.enable',       'default': 'false', 'description': 'enable_temporal_filter'},
+    {'name': 'disparity_filter.enable',      'default': 'false', 'description': 'enable_disparity_filter'},
+    {'name': 'hole_filling_filter.enable',   'default': 'false', 'description': 'enable_hole_filling_filter'},
+    {'name': 'hdr_merge.enable',             'default': 'false', 'description': 'hdr_merge filter enablement flag'},
+    {'name': 'wait_for_device_timeout',      'default': '-1.', 'description': 'Timeout for waiting for device to connect (Seconds)'},  # noqa: E501
+    {'name': 'reconnect_timeout',            'default': '6.', 'description': 'Timeout(seconds) between consecutive reconnection attempts'},  # noqa: E501
+    {'name': 'camera.aligned_depth_to_color.image_raw.png_level', 'default': '1', 'description': ''},
+    {'name': 'gripper_camera.aligned_depth_to_color.image_raw.png_level', 'default': '1', 'description': ''},
+    {'name': 'color_qos', 'default': 'SENSOR_DATA', 'description': ''},
+    {'name': 'depth_qos', 'default': 'SENSOR_DATA', 'description': ''},
+    {'name': 'infra_qos', 'default': 'SENSOR_DATA', 'description': ''},
 ]
+d435_parameter_overrides = {
+    'camera_name': 'camera',
+    'device_type': 'd435',
+    'json_file_path': json_path,
+    'depth_module.profile': D435_RESOLUTION,
+    'depth_module.depth_profile': D435_RESOLUTION,
+    'depth_module.infra_profile': D435_RESOLUTION,
+    'rgb_camera.profile': D435_RESOLUTION,
+    'rgb_camera.color_profile': D435_RESOLUTION,
+    'enable_infra1': 'true',
+    'gyro_fps': '200',
+    'accel_fps': '100',
+    'enable_gyro': 'true',
+    'enable_accel': 'true',
+    'pointcloud.enable': 'true',
+    'enable_sync': 'true',
+    'align_depth.enable': 'true',
+    'initial_reset': 'true',
+    'allow_no_texture_points': 'true',
+}
+d405_parameter_overrides = {
+    'camera_name': 'gripper_camera',
+    'device_type': 'd405',
+    'json_file_path': json_path,
+    'depth_module.profile': D405_RESOLUTION,
+    'depth_module.depth_profile': D405_RESOLUTION,
+    'depth_module.infra_profile': D405_RESOLUTION,
+    'rgb_camera.profile': D405_RESOLUTION,
+    'depth_module.color_profile': D405_RESOLUTION,
+    'gyro_fps': '200',
+    'accel_fps': '100',
+    'enable_gyro': 'true',
+    'enable_accel': 'true',
+    'pointcloud.enable': 'true',
+    'enable_sync': 'true',
+    'align_depth.enable': 'true',
+    # 'initial_reset': 'true', # TODO: Look into whether this should be True!
+    'allow_no_texture_points': 'true',
+}
+# fmt: on
+
+
+def apply_parameter_overrides(base_parameters, parameter_overrides):
+    params = []
+    for param in base_parameters:
+        name = param["name"]
+        default = param["default"]
+        description = param["description"]
+        params.append(
+            {
+                "name": name,
+                "default": parameter_overrides[name]
+                if name in parameter_overrides
+                else default,
+                "description": description,
+            }
+        )
+    return params
+
+
+def set_configurable_parameters(local_params):
+    return dict(
+        [
+            (param["original_name"], LaunchConfiguration(param["name"]))
+            for param in local_params
+        ]
+    )
 
 
 def declare_configurable_parameters(parameters):
@@ -154,46 +174,113 @@ def declare_configurable_parameters(parameters):
     ]
 
 
-def set_configurable_parameters(parameters):
-    return dict(
-        [(param["name"], LaunchConfiguration(param["name"])) for param in parameters]
+def append_to_parameter_names(params, suffix):
+    for param in params:
+        param["original_name"] = param["name"]
+        param["name"] += suffix
+
+
+def yaml_to_dict(path_to_yaml):
+    with open(path_to_yaml, "r") as f:
+        return yaml.load(f, Loader=yaml.SafeLoader)
+
+
+def launch_setup(context, params, param_name_suffix="", remappings=[]):
+    _config_file = LaunchConfiguration("config_file" + param_name_suffix).perform(
+        context
     )
+    params_from_file = {} if _config_file == "''" else yaml_to_dict(_config_file)
+
+    _output = LaunchConfiguration("output" + param_name_suffix)
+
+    return [
+        Node(
+            package="realsense2_camera",
+            namespace=LaunchConfiguration("camera_namespace" + param_name_suffix),
+            name=LaunchConfiguration("camera_name" + param_name_suffix),
+            executable="realsense2_camera_node",
+            parameters=[params, params_from_file],
+            output=_output,
+            arguments=[
+                "--ros-args",
+                "--log-level",
+                LaunchConfiguration("log_level" + param_name_suffix),
+            ],
+            emulate_tty=True,
+            remappings=remappings,
+        )
+    ]
 
 
 def generate_launch_description():
-    realsense_launch = GroupAction(
-        actions=[
-            SetRemap(
-                src="/gripper_camera/color/image_rect_raw",
-                dst="/gripper_camera/image_raw",
-            ),
-            SetRemap(
-                src="/gripper_camera/color/image_rect_raw/compressed",
-                dst="/gripper_camera/image_raw/compressed",
-            ),
-            IncludeLaunchDescription(
-                PythonLaunchDescriptionSource(
-                    [
-                        os.path.join(
-                            get_package_share_directory("realsense2_camera"), "launch"
-                        ),
-                        "/rs_multi_camera_launch.py",
-                    ]
-                )
-            ),
-        ]
+    # Apply camera-specific parameter overrides
+    d435_params = apply_parameter_overrides(
+        base_configurable_parameters, d435_parameter_overrides
+    )
+    d405_params = apply_parameter_overrides(
+        base_configurable_parameters, d405_parameter_overrides
     )
 
-    d435i_accel_correction = Node(
-        package="stretch_core",
-        executable="d435i_accel_correction",
-        output="screen",
+    # Add the depth compression level parameter
+    d435_params.append(
+        {
+            "name": f"{d435_parameter_overrides['camera_name']}.aligned_depth_to_color.image_raw.png_level",
+            "default": "1",  # PNG level 1 is the fastest
+            "description": "Compression level for aligned depth",
+        }
+    )
+    d405_params.append(
+        {
+            "name": f"{d405_parameter_overrides['camera_name']}.aligned_depth_to_color.image_raw.png_level",
+            "default": "1",  # PNG level 1 is the fastest
+            "description": "Compression level for aligned depth",
+        }
     )
 
-    return LaunchDescription(
-        declare_configurable_parameters(configurable_parameters)
-        + [
-            realsense_launch,
-            d435i_accel_correction,
-        ]
+    # Map each camera to a suffix
+    params_to_suffix = [
+        (d435_params, "1", []),
+        (
+            d405_params,
+            "2",
+            [
+                ("/gripper_camera/color/image_rect_raw", "/gripper_camera/image_raw"),
+                (
+                    "/gripper_camera/color/image_rect_raw/compressed",
+                    "/gripper_camera/image_raw/compressed",
+                ),
+            ],
+        ),
+    ]
+
+    # Create the launch description
+    ld = []
+    for params, suffix, remappings in params_to_suffix:
+        # Append the suffix to the parameter names
+        append_to_parameter_names(params, suffix)
+
+        # Declare the parameters
+        ld += declare_configurable_parameters(params)
+
+        # Create the node for these params
+        ld.append(
+            OpaqueFunction(
+                function=launch_setup,
+                kwargs={
+                    "params": set_configurable_parameters(params),
+                    "param_name_suffix": suffix,
+                    "remappings": remappings,
+                },
+            )
+        )
+
+    # Add the D435i accel correction node
+    ld.append(
+        Node(
+            package="stretch_core",
+            executable="d435i_accel_correction",
+            output="screen",
+        )
     )
+
+    return LaunchDescription(ld)

--- a/launch/web_interface.launch.py
+++ b/launch/web_interface.launch.py
@@ -417,19 +417,29 @@ def generate_launch_description():
     ld.add_action(rosbridge_launch)
 
     # Configure Video Streams
-    configure_video_streams_node = Node(
-        package="stretch_web_teleop",
-        executable="configure_video_streams.py",
-        output="screen",
-        arguments=[LaunchConfiguration("params"), str(stretch_has_beta_teleop_kit)],
-        parameters=[
-            {
-                "has_beta_teleop_kit": stretch_has_beta_teleop_kit,
-                "stretch_tool": stretch_tool,
-            }
-        ],
-    )
-    ld.add_action(configure_video_streams_node)
+    labels = ["overhead", "realsense", "gripper"]
+    for i in range(len(labels)):
+        bools = ["False", "False", "False"]
+        bools[i] = "True"
+        label = labels[i]
+        configure_video_streams_node = Node(
+            package="stretch_web_teleop",
+            executable="configure_video_streams.py",
+            name=f"configure_video_streams_{label}",
+            output="screen",
+            arguments=[
+                LaunchConfiguration("params"),
+                str(stretch_has_beta_teleop_kit),
+                *bools,
+            ],
+            parameters=[
+                {
+                    "has_beta_teleop_kit": stretch_has_beta_teleop_kit,
+                    "stretch_tool": stretch_tool,
+                }
+            ],
+        )
+        ld.add_action(configure_video_streams_node)
 
     rplidar_launch = IncludeLaunchDescription(
         PythonLaunchDescriptionSource([stretch_core_path, "/launch/rplidar.launch.py"])

--- a/nodes/compressed_image_visualizer.py
+++ b/nodes/compressed_image_visualizer.py
@@ -12,6 +12,7 @@ import rclpy
 from cv_bridge import CvBridge
 from rclpy.executors import MultiThreadedExecutor
 from rclpy.node import Node
+from rclpy.qos import QoSProfile, ReliabilityPolicy
 from sensor_msgs.msg import CompressedImage
 
 # Local imports
@@ -37,7 +38,7 @@ class CompressedImageVisualizer(Node):
             CompressedImage,
             "/camera/color/image_raw/compressed",
             self.compressed_img_callback,
-            1,
+            QoSProfile(depth=1, reliability=ReliabilityPolicy.BEST_EFFORT),
         )
 
         self.get_logger().info("Compressed Image Visualizer node initialized.")

--- a/nodes/configure_video_streams.py
+++ b/nodes/configure_video_streams.py
@@ -561,8 +561,9 @@ class ConfigureVideoStreams(Node):
         # Detect the gripper markers
         corners, ids, _ = self.aruco_detector.detectMarkers(image)
         if ids is None:
-            self.get_logger().warn(
-                "Did not detect any aruco markers. Skipping point cloud processing."
+            self.get_logger().debug(
+                "Did not detect any aruco markers on the gripper. Skipping point cloud processing.",
+                throttle_duration_sec=1.0,
             )
             return image
         aruco_center_pos = {}
@@ -579,8 +580,9 @@ class ConfigureVideoStreams(Node):
             "finger_left" not in aruco_center_pos
             or "finger_right" not in aruco_center_pos
         ):
-            self.get_logger().warn(
-                "Did not detect both aruco markers. Skipping point cloud processing."
+            self.get_logger().debug(
+                "Did not detect both aruco markers on the gripper. Skipping point cloud processing.",
+                throttle_duration_sec=1.0,
             )
             return image
 

--- a/src/pages/operator/tsx/function_providers/UnderVideoFunctionProvider.tsx
+++ b/src/pages/operator/tsx/function_providers/UnderVideoFunctionProvider.tsx
@@ -23,7 +23,8 @@ export enum UnderVideoButton {
   LookAtBase = "Look At Base",
   LookAhead = "Look Ahead",
   FollowGripper = "Follow Gripper",
-  DepthSensing = "Depth Sensing",
+  RealsenseDepthSensing = "Realsense Depth Sensing",
+  GripperDepthSensing = "Gripper Depth Sensing",
   ToggleArucoMarkers = "Toggle Aruco Markers",
   CenterWrist = "Center Wrist",
   StowWrist = "Stow Wrist",
@@ -147,10 +148,21 @@ export class UnderVideoFunctionProvider extends FunctionProvider {
           onCheck: (toggle: boolean) =>
             FunctionProvider.remoteRobot?.setToggle("setFollowGripper", toggle),
         };
-      case UnderVideoButton.DepthSensing:
+      case UnderVideoButton.RealsenseDepthSensing:
         return {
           onCheck: (toggle: boolean) =>
-            FunctionProvider.remoteRobot?.setToggle("setDepthSensing", toggle),
+            FunctionProvider.remoteRobot?.setToggle(
+              "setRealsenseDepthSensing",
+              toggle,
+            ),
+        };
+      case UnderVideoButton.GripperDepthSensing:
+        return {
+          onCheck: (toggle: boolean) =>
+            FunctionProvider.remoteRobot?.setToggle(
+              "setGripperDepthSensing",
+              toggle,
+            ),
         };
       case UnderVideoButton.StartMoveToPregraspHorizontal:
         horizontal = true;

--- a/src/pages/operator/tsx/index.tsx
+++ b/src/pages/operator/tsx/index.tsx
@@ -157,6 +157,7 @@ function handleWebRTCMessage(message: WebRTCMessage | WebRTCMessage[]) {
       hasBetaTeleopKit = message.value;
       break;
     case "stretchTool":
+      console.log("index stretchTool", message.value);
       stretchTool = getStretchTool(message.value);
       break;
     case "occupancyGrid":

--- a/src/pages/operator/tsx/layout_components/CameraView.tsx
+++ b/src/pages/operator/tsx/layout_components/CameraView.tsx
@@ -326,7 +326,6 @@ export const CameraView = (props: CustomizableComponentProps) => {
       ) : undefined}
     </div>
   );
-
   return (
     <div className="video-container" draggable={false}>
       {videoComponent}
@@ -633,6 +632,7 @@ function getStream(
 function executeVideoSettings(definition: CameraViewDefinition) {
   switch (definition.id) {
     case CameraViewId.gripper:
+      executeGripperSettings(definition as GripperVideoStreamDef);
       break;
     case CameraViewId.overhead:
       // executeFixedOverheadSettings(definition as FixedOverheadVideoStreamDef);
@@ -680,8 +680,20 @@ function executeAdjustableOverheadettings(
 function executeRealsenseSettings(definition: RealsenseVideoStreamDef) {
   underVideoFunctionProvider.provideFunctions(UnderVideoButton.FollowGripper)
     .onCheck!(definition.followGripper || false);
-  underVideoFunctionProvider.provideFunctions(UnderVideoButton.DepthSensing)
-    .onCheck!(definition.depthSensing || false);
+  underVideoFunctionProvider.provideFunctions(
+    UnderVideoButton.RealsenseDepthSensing,
+  ).onCheck!(definition.depthSensing || false);
+}
+
+/**
+ * Executes functions to prepare for rendering the Gripper video stream.
+ *
+ * @param definition {@link GripperVideoStreamDef}
+ */
+function executeGripperSettings(definition: GripperVideoStreamDef) {
+  underVideoFunctionProvider.provideFunctions(
+    UnderVideoButton.GripperDepthSensing,
+  ).onCheck!(definition.depthSensing || false);
 }
 
 /*******************************************************************************
@@ -962,7 +974,7 @@ const UnderRealsenseButtons = (props: {
           props.definition.depthSensing = !props.definition.depthSensing;
           setRerender(!rerender);
           underVideoFunctionProvider.provideFunctions(
-            UnderVideoButton.DepthSensing,
+            UnderVideoButton.RealsenseDepthSensing,
           ).onCheck!(props.definition.depthSensing);
         }}
         label="Depth Sensing"
@@ -1028,20 +1040,33 @@ const UnderGripperButtons = (props: {
       {props.betaTeleopKit ? (
         <></>
       ) : (
-        <CheckToggleButton
-          checked={props.definition.expandedGripperView || false}
-          onClick={() => {
-            if (!props.definition.expandedGripperView) {
-              props.setExpandedGripperView(true);
-              props.definition.expandedGripperView = true;
-            } else {
-              props.setExpandedGripperView(false);
-              props.definition.expandedGripperView = false;
-            }
-            setRerender(!rerender);
-          }}
-          label="Expanded Gripper View"
-        />
+        <React.Fragment>
+          <CheckToggleButton
+            checked={props.definition.expandedGripperView || false}
+            onClick={() => {
+              if (!props.definition.expandedGripperView) {
+                props.setExpandedGripperView(true);
+                props.definition.expandedGripperView = true;
+              } else {
+                props.setExpandedGripperView(false);
+                props.definition.expandedGripperView = false;
+              }
+              setRerender(!rerender);
+            }}
+            label="Expanded Gripper View"
+          />
+          <CheckToggleButton
+            checked={props.definition.depthSensing || false}
+            onClick={() => {
+              props.definition.depthSensing = !props.definition.depthSensing;
+              setRerender(!rerender);
+              underVideoFunctionProvider.provideFunctions(
+                UnderVideoButton.GripperDepthSensing,
+              ).onCheck!(props.definition.depthSensing);
+            }}
+            label="Depth Sensing"
+          />
+        </React.Fragment>
       )}
       {props.stretchTool === StretchTool.TABLET && (
         <button

--- a/src/pages/operator/tsx/layout_components/CameraView.tsx
+++ b/src/pages/operator/tsx/layout_components/CameraView.tsx
@@ -1055,17 +1055,20 @@ const UnderGripperButtons = (props: {
             }}
             label="Expanded Gripper View"
           />
-          <CheckToggleButton
-            checked={props.definition.depthSensing || false}
-            onClick={() => {
-              props.definition.depthSensing = !props.definition.depthSensing;
-              setRerender(!rerender);
-              underVideoFunctionProvider.provideFunctions(
-                UnderVideoButton.GripperDepthSensing,
-              ).onCheck!(props.definition.depthSensing);
-            }}
-            label="Depth Sensing"
-          />
+          {(props.stretchTool === StretchTool.GRIPPER ||
+            props.stretchTool === StretchTool.DEX_GRIPPER) && (
+            <CheckToggleButton
+              checked={props.definition.depthSensing || false}
+              onClick={() => {
+                props.definition.depthSensing = !props.definition.depthSensing;
+                setRerender(!rerender);
+                underVideoFunctionProvider.provideFunctions(
+                  UnderVideoButton.GripperDepthSensing,
+                ).onCheck!(props.definition.depthSensing);
+              }}
+              label="Depth Sensing"
+            />
+          )}
         </React.Fragment>
       )}
       {props.stretchTool === StretchTool.TABLET && (

--- a/src/pages/operator/tsx/utils/component_definitions.tsx
+++ b/src/pages/operator/tsx/utils/component_definitions.tsx
@@ -136,6 +136,10 @@ export type GripperVideoStreamDef = CameraViewDefinition & {
    * Whether to display the expanded gripper view or the default one
    */
   expandedGripperView?: boolean;
+  /**
+   * If pixels within the graspable region should be highlighted.
+   */
+  depthSensing?: boolean;
 };
 
 /**

--- a/src/pages/robot/tsx/index.tsx
+++ b/src/pages/robot/tsx/index.tsx
@@ -262,8 +262,11 @@ function handleMessage(message: WebRTCMessage) {
     case "setFollowGripper":
       robot.setPanTiltFollowGripper(message.toggle);
       break;
-    case "setDepthSensing":
-      robot.setDepthSensing(message.toggle);
+    case "setRealsenseDepthSensing":
+      robot.setRealsenseDepthSensing(message.toggle);
+      break;
+    case "setGripperDepthSensing":
+      robot.setGripperDepthSensing(message.toggle);
       break;
     case "setRunStop":
       robot.setRunStop(message.toggle);

--- a/src/pages/robot/tsx/robot.tsx
+++ b/src/pages/robot/tsx/robot.tsx
@@ -234,7 +234,7 @@ export class Robot extends React.Component {
   getHasBetaTeleopKit() {
     this.hasBetaTeleopKitParam = new ROSLIB.Param({
       ros: this.ros,
-      name: "/configure_video_streams:has_beta_teleop_kit",
+      name: "/configure_video_streams_gripper:has_beta_teleop_kit",
     });
 
     this.hasBetaTeleopKitParam.get((value: boolean) => {
@@ -248,7 +248,7 @@ export class Robot extends React.Component {
     // However, we only need it once, so opt for a parameter.
     this.stretchToolParam = new ROSLIB.Param({
       ros: this.ros,
-      name: "/configure_video_streams:stretch_tool",
+      name: "/configure_video_streams_gripper:stretch_tool",
     });
 
     this.stretchToolParam.get((value: string) => {

--- a/src/pages/robot/tsx/robot.tsx
+++ b/src/pages/robot/tsx/robot.tsx
@@ -42,7 +42,8 @@ export class Robot extends React.Component {
   private switchToNavigationService?: ROSLIB.Service;
   private switchToPositionService?: ROSLIB.Service;
   private setCameraPerspectiveService?: ROSLIB.Service;
-  private setDepthSensingService?: ROSLIB.Service;
+  private setRealsenseDepthSensingService?: ROSLIB.Service;
+  private setGripperDepthSensingService?: ROSLIB.Service;
   private setRunStopService?: ROSLIB.Service;
   private robotFrameTfClient?: ROSLIB.TFClient;
   private mapFrameTfClient?: ROSLIB.TFClient;
@@ -144,7 +145,8 @@ export class Robot extends React.Component {
     this.createCmdVelTopic();
     this.createSwitchToNavigationService();
     this.createSwitchToPositionService();
-    this.createDepthSensingService();
+    this.createRealsenseDepthSensingService();
+    this.createGripperDepthSensingService();
     this.createRunStopService();
     this.createRobotFrameTFClient();
     this.createMapFrameTFClient();
@@ -409,10 +411,18 @@ export class Robot extends React.Component {
     });
   }
 
-  createDepthSensingService() {
-    this.setDepthSensingService = new ROSLIB.Service({
+  createRealsenseDepthSensingService() {
+    this.setRealsenseDepthSensingService = new ROSLIB.Service({
       ros: this.ros,
-      name: "/depth_ar",
+      name: "/realsense_depth_ar",
+      serviceType: "std_srvs/srv/SetBool",
+    });
+  }
+
+  createGripperDepthSensingService() {
+    this.setGripperDepthSensingService = new ROSLIB.Service({
+      ros: this.ros,
+      name: "/gripper_depth_ar",
       serviceType: "std_srvs/srv/SetBool",
     });
   }
@@ -478,13 +488,28 @@ export class Robot extends React.Component {
     });
   }
 
-  setDepthSensing(toggle: boolean) {
+  setRealsenseDepthSensing(toggle: boolean) {
     var request = new ROSLIB.ServiceRequest({ data: toggle });
-    this.setDepthSensingService?.callService(request, (response: boolean) => {
-      response
-        ? console.log("Enable depth sensing")
-        : console.log("Disabled depth sensing");
-    });
+    this.setRealsenseDepthSensingService?.callService(
+      request,
+      (response: boolean) => {
+        response
+          ? console.log("Enable realsense depth sensing")
+          : console.log("Disabled realsense depth sensing");
+      },
+    );
+  }
+
+  setGripperDepthSensing(toggle: boolean) {
+    var request = new ROSLIB.ServiceRequest({ data: toggle });
+    this.setGripperDepthSensingService?.callService(
+      request,
+      (response: boolean) => {
+        response
+          ? console.log("Enable gripper depth sensing")
+          : console.log("Disabled gripper depth sensing");
+      },
+    );
   }
 
   setRunStop(toggle: boolean) {

--- a/src/shared/commands.tsx
+++ b/src/shared/commands.tsx
@@ -62,7 +62,11 @@ export interface CameraPerspectiveCommand {
 }
 
 export interface ToggleCommand {
-  type: "setFollowGripper" | "setDepthSensing" | "setRunStop";
+  type:
+    | "setFollowGripper"
+    | "setRealsenseDepthSensing"
+    | "setGripperDepthSensing"
+    | "setRunStop";
   toggle: boolean;
 }
 

--- a/src/shared/remoterobot.tsx
+++ b/src/shared/remoterobot.tsx
@@ -158,7 +158,11 @@ export class RemoteRobot extends React.Component<{}, any> {
   }
 
   setToggle(
-    type: "setFollowGripper" | "setDepthSensing" | "setRunStop",
+    type:
+      | "setFollowGripper"
+      | "setRealsenseDepthSensing"
+      | "setGripperDepthSensing"
+      | "setRunStop",
     toggle: boolean,
   ) {
     let cmd: ToggleCommand = {

--- a/stretch_web_teleop_helpers/stretch_ik_control.py
+++ b/stretch_web_teleop_helpers/stretch_ik_control.py
@@ -253,10 +253,19 @@ class StretchIKControl:
         for joint_name in Joint:
             if joint_name in joint_map:
                 module, vel_key = joint_map[joint_name]
-                max_abs_vel = robot_params[module]["motion"][speed_profile_str][vel_key]
-                min_abs_vel = robot_params[module]["motion"][speed_profile_slow_str][
-                    vel_key
-                ]
+                try:
+                    max_abs_vel = robot_params[module]["motion"][speed_profile_str][
+                        vel_key
+                    ]
+                    min_abs_vel = robot_params[module]["motion"][
+                        speed_profile_slow_str
+                    ][vel_key]
+                except KeyError:
+                    self.node.get_logger().error(
+                        f"Failed to get velocity limits for joint name: {joint_name}"
+                    )
+                    max_abs_vel = 0.0
+                    min_abs_vel = 0.0
             elif joint_name == Joint.BASE_ROTATION:
                 # https://github.com/hello-robot/stretch_visual_servoing/blob/f99342/normalized_velocity_control.py#L21
                 max_abs_vel = 0.5  # rad/s


### PR DESCRIPTION
# Description

This PR adds a gripper depth overlay, which highlights points within the graspable region.

# Testing procedure

- [x] On a Stretch with the D405:
    - [x] Click depth sending under the gripper camera, verify it works.
    - [x] Verify it doesn't significantly worsen the latency. (If did, but see #61 for the fix.)
    - [x] Uncheck it, verify it works.
    - [x] Verify the highlighted points are actually in the graspable region.
    - [x] Use it with click-to-pregrasp, for both horizontal and vertical grasps. Verify it helps to grasp objects.
- [x] Attach a tablet and switch the tool using `stretch_configure_tool.py`, verify that the depth sensing feature does not appear on the web app.
- [x] On a Stretch with the beta teleop kit:
    - [x] Verify the "Depth Sensing" option does not appear below the gripper camera.

# Before opening a pull request

From the top-level of this repository, run:

- \[ \] `pre-commit run --all-files`

# To merge

- \[ \] `Squash & Merge`
