### PR TITLE
Bugfix: re-enable separate tablet stow configuration

### DIFF
--- a/src/pages/operator/tsx/function_providers/UnderVideoFunctionProvider.tsx
+++ b/src/pages/operator/tsx/function_providers/UnderVideoFunctionProvider.tsx
@@ -11,6 +11,7 @@ import {
   TabletOrientation,
   TABLET_ORIENTATION_LANDSCAPE,
   TABLET_ORIENTATION_PORTRAIT,
+  StretchTool,
 } from "../../../../shared/util";
 import { stretchTool } from "..";
 
@@ -127,7 +128,7 @@ export class UnderVideoFunctionProvider extends FunctionProvider {
             FunctionProvider.remoteRobot?.setRobotPose(CENTER_WRIST),
         };
       case UnderVideoButton.StowWrist:
-        if (stretchTool === "eoa_wrist_dw3_tool_tablet_12in") {
+        if (stretchTool === StretchTool.TABLET) {
           return {
             onClick: () =>
               FunctionProvider.remoteRobot?.setRobotPose(STOW_WRIST_TABLET),


### PR DESCRIPTION
# Description

This PR addresses a bug that prevented the robot from executing the tablet-specific stow configuration.

# Testing procedure

- [x] Plug in the tablet, switch the tool to the tablet using `stretch_configure_tool.py`
- [x] Run the web app, stow the wrist, verify it correctly stows the tablet.

# Before opening a pull request

From the top-level of this repository, run:

- \[ \] `pre-commit run --all-files`

# To merge

- \[ \] `Squash & Merge`
