### PR TITLE
Bugfix: change Look at Gripper to Look at Tablet

### DIFF
--- a/src/pages/operator/tsx/layout_components/CameraView.tsx
+++ b/src/pages/operator/tsx/layout_components/CameraView.tsx
@@ -656,6 +656,7 @@ const UnderVideoButtons = (props: {
         <UnderAdjustableOverheadButtons
           definition={props.definition}
           setPredictiveDisplay={props.setPredictiveDisplay}
+          stretchTool={props.stretchTool}
         />
       );
       break;
@@ -708,6 +709,7 @@ const UnderOverheadButtons = (props: {
 const UnderAdjustableOverheadButtons = (props: {
   definition: AdjustableOverheadVideoStreamDef;
   setPredictiveDisplay: (enabled: boolean) => void;
+  stretchTool: StretchTool;
 }) => {
   const [rerender, setRerender] = React.useState<boolean>(false);
 
@@ -715,7 +717,12 @@ const UnderAdjustableOverheadButtons = (props: {
     <React.Fragment>
       <AccordionSelect
         title="Look..."
-        possibleOptions={Object.values(realsenseButtons)}
+        possibleOptions={realsenseButtons.map((button) => {
+          if (button === UnderVideoButton.LookAtGripper) {
+            return "Look at " + getGripperLabel(props.stretchTool);
+          }
+          return button;
+        })}
         onChange={(idx: number) => {
           underVideoFunctionProvider.provideFunctions(realsenseButtons[idx])
             .onClick!();
@@ -730,7 +737,7 @@ const UnderAdjustableOverheadButtons = (props: {
             UnderVideoButton.FollowGripper,
           ).onCheck!(props.definition.followGripper);
         }}
-        label={getFollowGripperLabel()}
+        label={"Follow " + getGripperLabel(props.stretchTool)}
       />
       <CheckToggleButton
         checked={props.definition.predictiveDisplay || false}
@@ -768,7 +775,12 @@ const UnderRealsenseButtons = (props: {
     <React.Fragment>
       <AccordionSelect
         title="Look..."
-        possibleOptions={Object.values(realsenseButtons)}
+        possibleOptions={realsenseButtons.map((button) => {
+          if (button === UnderVideoButton.LookAtGripper) {
+            return "Look at " + getGripperLabel(props.stretchTool);
+          }
+          return button;
+        })}
         onChange={(idx: number) => {
           underVideoFunctionProvider.provideFunctions(realsenseButtons[idx])
             .onClick!();
@@ -783,7 +795,7 @@ const UnderRealsenseButtons = (props: {
             UnderVideoButton.FollowGripper,
           ).onCheck!(props.definition.followGripper);
         }}
-        label={getFollowGripperLabel(props.stretchTool)}
+        label={"Follow " + getGripperLabel(props.stretchTool)}
       />
       <CheckToggleButton
         checked={props.definition.depthSensing || false}
@@ -908,13 +920,14 @@ const CameraPerspectiveButton = (props: {
   return <button onClick={onClick}>{props.perspective}</button>;
 };
 
-function getFollowGripperLabel(stretchTool: StretchTool) {
+function getGripperLabel(stretchTool: StretchTool) {
+  console.log("getGripperLabel stretchTool", stretchTool);
   switch (stretchTool) {
     case StretchTool.TABLET:
-      return "Follow Tablet";
+      return "Tablet";
     case StretchTool.GRIPPER:
-      return "Follow Gripper";
+      return "Gripper";
     default:
-      return "Follow Wrist";
+      return "Wrist";
   }
 }


### PR DESCRIPTION
# Description

#55 fixed a bug where "Follow Gripper" doesn't work when the tablet is attached. This PR extends upon that by also changing the text of "Look at Gripper" to "Look at Tablet / Wrist" depending on the tool.

# Testing procedure

- [x] Connect it with a tablet, run `stretch_configure_tool.py`
- [x] Verify that the `Look...` shows "Look at Tablet" and that button works, for both the realsense and nav cam
- [x] Connect it to a gripper, run `stretch_configure_tool.py`
- [x] Verify that the `Look...` shows "Look at Gripper" and that button works.

# Before opening a pull request

From the top-level of this repository, run:

- \[ \] `pre-commit run --all-files`

# To merge

- \[ \] `Squash & Merge`
