### PR TITLE
Temp fix for wrist dropping issue: don't send `stop` commands

### DIFF
--- a/src/pages/operator/tsx/function_providers/FunctionProvider.tsx
+++ b/src/pages/operator/tsx/function_providers/FunctionProvider.tsx
@@ -80,11 +80,13 @@ export abstract class FunctionProvider {
     }, 150);
   }
 
-  public stopCurrentAction() {
-    FunctionProvider.remoteRobot?.stopTrajectory();
+  public stopCurrentAction(send_stop_command: boolean = false) {
+    if (send_stop_command) FunctionProvider.remoteRobot?.stopTrajectory();
     if (this.activeVelocityAction) {
-      // No matter what region this is, stop the currently running action
-      this.activeVelocityAction.stop();
+      // TODO: this.activeVelocityAction.stop sometimes (always?) executes the
+      // exact same cancellation command(s) as FunctionProvider.remoteRobot?.stopTrajectory,
+      // which means we are unnecessarily calling it twice.
+      if (send_stop_command) this.activeVelocityAction.stop();
       this.activeVelocityAction = undefined;
     }
     if (this.velocityExecutionHeartbeat) {


### PR DESCRIPTION
# Description

This PR provides a temporary fix for [`stretch_ros2`#140](https://github.com/hello-robot/stretch_ros2/issues/140), where the wrist pitch falls if trajectory cancel requests are invoked in rapid sequence. This issue manifests on the web app if an operator spams a button in press-and-hold mode (and maybe other modes as well).

The way this PR fixes it is by **_removing all "stop trajectory" commands that are sent to `stretch_driver` from the web app_**. This is far from an ideal solution, because what that means is that trajectories cannot be interrupted. e.g., if an operator is in the "Fastest" speed and presses "arm lift up" but immediately lets it go since they made a mistake, the arm will still move the entire 12cm up. However, it is important to note that this **_does not harm current functionality_**, because the bug in [`stretch_ros2`#139](https://github.com/hello-robot/stretch_ros2/issues/139) results in `stretch_driver` not processing cancellation commands anyway, and executing the trajectory to completion even if a cancellation was invoked.

Thus, I propose the following:
1. We merge this in, to fix the wrist pitch dropping issue.
2. Once [`stretch_ros2`#139](https://github.com/hello-robot/stretch_ros2/issues/139) and [`stretch_ros2`#140](https://github.com/hello-robot/stretch_ros2/issues/140) are addressed, we re-add "stop trajectory" commands (which can be easily toggled by a boolean flag). This will add the desirable behavior (which has never been present in this web app) of immediately stopping motion, as opposed to waiting until the previously-commanded incremental motion finished. 

# Testing procedure

- [x] **Recreate the issue**: pull `master`, re-build the workspace, and launch the app `./launch_interface`. In the operator interface, spam "wrist pitch up". Verify that the wrist falls.
- [x] **Verify the fix**: pull this branch,  re-build the workspace, and launch the app `./launch_interface`. In the operator interface, spam "wrist pitch up". Verify that the wrist does not fall.
- [x] **Verify no negative consequences**: In each of the below modes, on the "Fastest" speed, click all joint motion (base translate, base rotate, wrist pitch, wrist roll, wrist yaw, arm lift, arm length) and verify that the motion never continues forever. 
    - [x] Press-and-hold
    - [x] Click-click
    - [x] Step-actions
- [x] Run the above tests on the following configurations:
    - [x] Stretch 3
    - [ ] Stretch 2

# Before opening a pull request

From the top-level of this repository, run:

- [ ] `pre-commit run --all-files`

# To merge

- [ ] `Squash & Merge`
