### PR TITLE
Cancel Autonomous Behaviors when Joints are Moved

### DIFF
--- a/src/pages/robot/tsx/robot.tsx
+++ b/src/pages/robot/tsx/robot.tsx
@@ -754,7 +754,7 @@ export class Robot extends React.Component {
 
   executeIncrementalMove(jointName: ValidJoints, increment: number) {
     this.switchToPositionMode();
-    this.stopExecution();
+    this.stopAutonomousClients();
     this.poseGoal = this.makeIncrementalMoveGoal(jointName, increment);
     this.trajectoryClient.createClient(this.poseGoal);
   }
@@ -764,6 +764,11 @@ export class Robot extends React.Component {
     this.stopMoveBaseClient();
     this.stopMoveToPregraspClient();
   }
+
+  stopAutonomousClients() {
+    this.stopMoveBaseClient();
+    this.stopMoveToPregraspClient();
+  }  
 
   stopTrajectoryClient() {
     if (!this.trajectoryClient) throw "trajectoryClient is undefined";

--- a/src/pages/robot/tsx/robot.tsx
+++ b/src/pages/robot/tsx/robot.tsx
@@ -731,12 +731,14 @@ export class Robot extends React.Component {
 
   executePoseGoal(pose: RobotPose) {
     this.switchToPositionMode();
+    this.stopExecution();
     this.poseGoal = this.makePoseGoal(pose);
     this.trajectoryClient.createClient(this.poseGoal);
   }
 
   async executePoseGoals(poses: RobotPose[], index: number) {
     this.switchToPositionMode();
+    this.stopExecution();
     this.poseGoal = this.makePoseGoals(poses);
     this.trajectoryClient.createClient(this.poseGoal);
   }
@@ -752,6 +754,7 @@ export class Robot extends React.Component {
 
   executeIncrementalMove(jointName: ValidJoints, increment: number) {
     this.switchToPositionMode();
+    this.stopExecution();
     this.poseGoal = this.makeIncrementalMoveGoal(jointName, increment);
     this.trajectoryClient.createClient(this.poseGoal);
   }

--- a/src/pages/robot/tsx/robot.tsx
+++ b/src/pages/robot/tsx/robot.tsx
@@ -768,7 +768,7 @@ export class Robot extends React.Component {
   stopAutonomousClients() {
     this.stopMoveBaseClient();
     this.stopMoveToPregraspClient();
-  }  
+  }
 
   stopTrajectoryClient() {
     if (!this.trajectoryClient) throw "trajectoryClient is undefined";


### PR DESCRIPTION
# Description

PR to address Issue #65. Autonomous behaviors were previously not cancelled when the arm, wrist, gripper, and camera joints were moved by the operator. This PR has includes a fix to stop any action in execution when any of these joints are moved. 

# Testing procedure

 - [x] Pull this PR.
 - [x] Launch the interface: `colcon_cd stretch_web_teleop; ./launch_interface.sh`
 - [x] Initiate click-to-pregrasp and confirm it cancels when you execute the following actions:
     - [x] Move the base (either through button pad or predictive display)
     - [x] Move the arm
     - [x] Move the wrist
     - [x] Move the gripper
     - [x] Move the camera
     - [x] Click the 'Look...' button and select any option
     - [x] Click the 'Quick Actions...' button and select any option
     - [x] Click 'Follow Gripper'
- [x] Repeat the above tests for the following systems using both click-to-pregrasp and autonomous navigation:
     - [x] Stretch 2
     - [x] Stretch 3

# Before opening a pull request

From the top-level of this repository, run:

- [ ] `pre-commit run --all-files`

# To merge

- [ ] `Squash & Merge`
