### PR TITLE
Make Prepare Special URDF script fail with success exit code

### DIFF
--- a/prepare_specialized_urdf.py
+++ b/prepare_specialized_urdf.py
@@ -98,7 +98,9 @@ print("The specialized URDFs will be derived from this URDF.")
 try:
     robot = ud.Robot.from_xml_file(urdf_filename)
 except FileNotFoundError:
-    print(f"The URDF file was not found in path {urdf_filename}. Unable to create specialized URDFs.")
+    print(
+        f"The URDF file was not found in path {urdf_filename}. Unable to create specialized URDFs."
+    )
     sys.exit(0)
 
 # Change any joint that should be immobile for end effector IK into a fixed joint

--- a/prepare_specialized_urdf.py
+++ b/prepare_specialized_urdf.py
@@ -2,6 +2,7 @@
 import pathlib
 import pprint
 import subprocess
+import sys
 from typing import Dict, Optional, Tuple
 
 # Third-party imports
@@ -94,7 +95,11 @@ print()
 print("Loading URDF from:")
 print(urdf_filename)
 print("The specialized URDFs will be derived from this URDF.")
-robot = ud.Robot.from_xml_file(urdf_filename)
+try:
+    robot = ud.Robot.from_xml_file(urdf_filename)
+except FileNotFoundError:
+    print(f"The URDF file was not found in path {urdf_filename}. Unable to create specialized URDFs.")
+    sys.exit(0)
 
 # Change any joint that should be immobile for end effector IK into a fixed joint
 for j in robot.joint_map.keys():


### PR DESCRIPTION
# Description

Prepare specialized URDF script fails with error code if unable to find URDF in an export folder which is expected during fresh production installs, stopping the Stretch Install shell scripts. Therefore this PR adds a try exception block to exit the script with success status after notifying the failure.

# Testing procedure
- [ ] Run [`stretch_create_ament_workspace.sh`](https://github.com/hello-robot/stretch_install/blob/master/factory/22.04/stretch_create_ament_workspace.sh) with an empty `exported_urdf` directory.

# Before opening a pull request

From the top-level of this repository, run:

- [ ] `pre-commit run --all-files`

# To merge

- [ ] `Squash & Merge`
