### PR TITLE
Add a certificate creation script

### DIFF
--- a/create_certificates.sh
+++ b/create_certificates.sh
@@ -9,7 +9,7 @@ rm -rf ~/.local/share/mkcert/root*
 cp root* ~/.local/share/mkcert
 mkcert ${HELLO_FLEET_ID} ${HELLO_FLEET_ID}.local ${HELLO_FLEET_ID}.dev localhost 127.0.0.1 0.0.0.0 ::1 
 rm mkcert-v*-linux-amd64
-cd $AMENT_WSDIR/src/stretch_web_teleop
+cd ..
 touch .env
 echo certfile=${HELLO_FLEET_ID}+6.pem >> .env
 echo keyfile=${HELLO_FLEET_ID}+6-key.pem >> .env

--- a/create_certificates.sh
+++ b/create_certificates.sh
@@ -1,0 +1,15 @@
+echo "Generating web interface certs..."
+cd certificates
+curl -JLO "https://dl.filippo.io/mkcert/latest?for=linux/amd64" 
+chmod +x mkcert-v*-linux-amd64
+sudo cp mkcert-v*-linux-amd64 /usr/local/bin/mkcert
+CAROOT=`pwd` mkcert --install
+mkdir -p ~/.local/share/mkcert
+rm -rf ~/.local/share/mkcert/root*
+cp root* ~/.local/share/mkcert
+mkcert ${HELLO_FLEET_ID} ${HELLO_FLEET_ID}.local ${HELLO_FLEET_ID}.dev localhost 127.0.0.1 0.0.0.0 ::1 
+rm mkcert-v*-linux-amd64
+cd $AMENT_WSDIR/src/stretch_web_teleop
+touch .env
+echo certfile=${HELLO_FLEET_ID}+6.pem >> .env
+echo keyfile=${HELLO_FLEET_ID}+6-key.pem >> .env

--- a/prepare_specialized_urdf.py
+++ b/prepare_specialized_urdf.py
@@ -98,7 +98,9 @@ print("The specialized URDFs will be derived from this URDF.")
 try:
     robot = ud.Robot.from_xml_file(urdf_filename)
 except FileNotFoundError:
-    print(f"The URDF file was not found in path {urdf_filename}. Unable to create specialized URDFs.")
+    print(
+        f"The URDF file was not found in path {urdf_filename}. Unable to create specialized URDFs."
+    )
     sys.exit(0)
 
 # Change any joint that should be immobile for end effector IK into a fixed joint

--- a/prepare_specialized_urdf.py
+++ b/prepare_specialized_urdf.py
@@ -2,6 +2,7 @@
 import pathlib
 import pprint
 import subprocess
+import sys
 from typing import Dict, Optional, Tuple
 
 # Third-party imports
@@ -94,7 +95,11 @@ print()
 print("Loading URDF from:")
 print(urdf_filename)
 print("The specialized URDFs will be derived from this URDF.")
-robot = ud.Robot.from_xml_file(urdf_filename)
+try:
+    robot = ud.Robot.from_xml_file(urdf_filename)
+except FileNotFoundError:
+    print(f"The URDF file was not found in path {urdf_filename}. Unable to create specialized URDFs.")
+    sys.exit(0)
 
 # Change any joint that should be immobile for end effector IK into a fixed joint
 for j in robot.joint_map.keys():


### PR DESCRIPTION
# Description
This PR adds a script to create certificates for the web teleop, which was previously part of the create ament_ws script from the Stretch Install repository. This has the advantage of modularizing the certificate creation step. It can be maintained only in this one stake-holding repository and just called from Stretch Install scripts.

# Testing procedure
- [ ] Run [create_certificates.sh](https://github.com/hello-robot/stretch_web_teleop/blob/246e38bf33c60cb131ed88e8782dada15e92af9f/create_certificates.sh) and make sure certificates are created.
# Before opening a pull request

From the top-level of this repository, run:

- [ ] `pre-commit run --all-files`

# To merge

- [ ] `Squash & Merge`
