### PR TITLE
Add auto-reconnect to ROS for the robot browser

### DIFF
--- a/launch/web_interface.launch.py
+++ b/launch/web_interface.launch.py
@@ -422,6 +422,7 @@ def generate_launch_description():
                 ]
             ),
             "authenticate": "false",
+            "call_services_in_new_thread": "true",
         }.items(),
     )
     ld.add_action(rosbridge_launch)

--- a/src/pages/robot/tsx/index.tsx
+++ b/src/pages/robot/tsx/index.tsx
@@ -58,8 +58,7 @@ connection = new WebRTCConnection({
   onMessage: handleMessage,
   onConnectionEnd: disconnectFromRobot,
 });
-
-robot.connect().then(() => {
+robot.setOnRosConnectCallback(() => {
   robot.subscribeToVideo({
     topicName: "/navigation_camera/image_raw/rotated/compressed",
     callback: navigationStream.updateImage,
@@ -85,6 +84,7 @@ robot.connect().then(() => {
 
   connection.joinRobotRoom();
 });
+robot.connect();
 
 function handleSessionStart() {
   connection.removeTracks();
@@ -280,12 +280,6 @@ function handleMessage(message: WebRTCMessage) {
     case "getHasBetaTeleopKit":
       robot.getHasBetaTeleopKit();
     case "moveToPregrasp":
-      console.log(
-        "moveToPregrasp",
-        message.scaled_x,
-        message.scaled_y,
-        message.horizontal,
-      );
       robot.executeMoveToPregraspGoal(
         message.scaled_x,
         message.scaled_y,

--- a/src/pages/robot/tsx/index.tsx
+++ b/src/pages/robot/tsx/index.tsx
@@ -58,7 +58,7 @@ connection = new WebRTCConnection({
   onMessage: handleMessage,
   onConnectionEnd: disconnectFromRobot,
 });
-robot.setOnRosConnectCallback(() => {
+robot.setOnRosConnectCallback(async () => {
   robot.subscribeToVideo({
     topicName: "/navigation_camera/image_raw/rotated/compressed",
     callback: navigationStream.updateImage,
@@ -83,6 +83,8 @@ robot.setOnRosConnectCallback(() => {
   robot.getJointLimits();
 
   connection.joinRobotRoom();
+
+  return Promise.resolve();
 });
 robot.connect();
 

--- a/src/pages/robot/tsx/videostreams.tsx
+++ b/src/pages/robot/tsx/videostreams.tsx
@@ -44,6 +44,7 @@ export class VideoStream extends React.Component<VideoStreamProps> {
   className?: string;
   outputVideoStream?: MediaStream;
   aspectRatio: any;
+  started: boolean;
 
   constructor(props: VideoStreamProps) {
     super(props);
@@ -58,6 +59,7 @@ export class VideoStream extends React.Component<VideoStreamProps> {
     this.video.setAttribute("width", this.width.toString());
     this.video.setAttribute("height", this.height.toString());
     this.outputVideoStream = new MediaStream();
+    this.started = false;
 
     this.updateImage = this.updateImage.bind(this);
   }
@@ -109,10 +111,13 @@ export class VideoStream extends React.Component<VideoStreamProps> {
   }
 
   start() {
-    if (!this.canvas.current) throw "Video stream canvas null";
-    this.outputVideoStream = this.canvas.current.captureStream(this.fps);
-    this.video.srcObject = this.outputVideoStream;
-    this.drawVideo();
+    if (!this.started) {
+      if (!this.canvas.current) throw "Video stream canvas null";
+      this.outputVideoStream = this.canvas.current.captureStream(this.fps);
+      this.video.srcObject = this.outputVideoStream;
+      this.drawVideo();
+      this.started = true;
+    }
   }
 
   render() {

--- a/src/pages/robot/tsx/videostreams.tsx
+++ b/src/pages/robot/tsx/videostreams.tsx
@@ -87,7 +87,7 @@ export class VideoStream extends React.Component<VideoStreamProps> {
       );
     }
     if (!this.imageReceived) {
-      let { width, height, data } = jpeg.decode(
+      let { width, height } = jpeg.decode(
         Uint8Array.from(atob(message.data), (c) => c.charCodeAt(0)),
         true,
       );
@@ -112,11 +112,14 @@ export class VideoStream extends React.Component<VideoStreamProps> {
 
   start() {
     if (!this.started) {
+      console.log("Starting video stream", this.streamName);
       if (!this.canvas.current) throw "Video stream canvas null";
       this.outputVideoStream = this.canvas.current.captureStream(this.fps);
       this.video.srcObject = this.outputVideoStream;
       this.drawVideo();
       this.started = true;
+    } else {
+      console.log("Video stream already started", this.streamName);
     }
   }
 

--- a/src/shared/webrtcconnections.tsx
+++ b/src/shared/webrtcconnections.tsx
@@ -61,7 +61,7 @@ export class WebRTCConnection extends React.Component {
     this.socket = io();
 
     this.socket.on("connect", () => {
-      console.log("socket connected");
+      console.log("WebRTCConnection socket connected");
     });
 
     this.socket.on("join", (room: string) => {


### PR DESCRIPTION
# Description

This PR depends on our fork of [`roslibjs`#1](https://github.com/hello-vinitha/roslibjs/pull/1). Although, for backwards compatibility, I have ported that code locally as well.

This PR addresses the following related bugs:
1. If the robot browser launches before rosbridge is running, it will never join the robot room, which means the operator will never be allowed to join the operator room.
2. If the robot browser launches too quickly after rosbridge, sometimes it invokes the `/get_joint_states` service before the service is actually ready, which results in it hanging. After that point, no other service invokation or topic publication from the web app will be received by rosbridge, and the only way to resolve it is to run `pm2 restart start_robot_browser`

This PR addresses them, respectively, by:
1. Adding an auto-reconnect every 1 second if the ROS connection gets closed or encounters an error.
2. This was resolved with two changes:
    1. Having rosbridge launch services in a separate thread, so that even if one service invocation hangs, it doesn't harm other rosbridge communications.
    2. Waiting until several key topics have at least one publisher, before the robot browser proceeds.

# Testing procedure

- [x] Recreate the issue: Pull the code on `master`.
    - [x] To recreate the first issue, add an artificial delay in launching rosbridge by adding a `import time; time.sleep(5.0)` to `web_interface.launch.py` before returning the launch description, and re-build the workspace. Run `./launch_interface.sh`, load the operator browser, and verify it only shows the loading icon forevor (e.g., even if you refresh after 5 seconds once `rosbridge` has loaded, it still won't load)
    - [x] Recreating the second issue is difficult. I'd recommend trying `./launch_interface.sh` and `./stop_interface` until you experience the issue on the operator browser. A tell-tale sign of this issue is if the tool-specific features you expect to be enabled (e.g., click-to-pregrasp) are (because that means `rosbridge` did not return the tool parameter). I had to run the interface 7 times before experiencing the issue, but once I did, I verified that no commands from the web app were going through to rosbridge. At that stage, even if you refresh the page, ros commands still don't go through.
- [x] Verify the solution: Pull the code from this branch and re-build your workspace. Also, update npm's `roslibjs` dependency to point to the branch in [`roslibjs`#1](https://github.com/hello-vinitha/roslibjs/pull/1) (or the same branch if that has been merged in).
    - [x] Add the artificial delay in the launchfile (see above) and re-build the workspace. Run `./launch_interface.sh`. Load the operator interface asap. Verify that it shows the loading icon initially, but after ~5 seconds when rosbridge loads, it loads correctly (without needing you to refresh the page).
    - [x] Remove the artificial delay and re-build. Launch the interface and verify all video streams are live and motion commands are executed. Attach to the screen session (`screen -r web_teleop_ros`) and terminate it (`Ctrl-c`). Verify the video streams have stopped updating. Now, launch a new screen session (`screen -dm -S "web_teleop_ros" ros2 launch stretch_web_teleop web_interface.launch.py`). Verify that **_without needing to refresh the operator page_**, the video streams start back up again and commands start executing again.
    - [x] Launch the interface, load the operator browser, and then stop the interface 10 times. Verify that the aforementioned issue never arises (in the few cases where the page doesn't show the features you expect, refreshing the operator interface should fix it).

# Before opening a pull request

From the top-level of this repository, run:

- [ ] `pre-commit run --all-files`

# To merge

- [ ] `Squash & Merge`
