### PR TITLE
Add a script to configure audio devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ The interface is compatible with the Stretch RE1, RE2 and SE3. It currently only
 
 ## Audio configuration
 
+We provide a convenience script `./configure_audio.sh` to configure your audio devices. Depending on desired audio configuration, you may need to pass in speaker and mic names (see the comment in the script itself for usage details). Below, we detail additional commands that could help configure your audio.
+
 ### Audio Devices
 
 For robot-to-operator audio streaming, the web interfaces uses the robot's system default microphone if one or more external microphones are plugged in, or the built-in robot microphone if no external microphones are plugged in.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ The interface is compatible with the Stretch RE1, RE2 and SE3. It currently only
 
 We provide a convenience script `./configure_audio.sh` to configure your audio devices. Depending on desired audio configuration, you may need to pass in speaker and mic names (see the comment in the script itself for usage details). Below, we detail additional commands that could help configure your audio.
 
+You may need to re-run audio configuration every time you re-start your Stretch.
+
 ### Audio Devices
 
 For robot-to-operator audio streaming, the web interfaces uses the robot's system default microphone if one or more external microphones are plugged in, or the built-in robot microphone if no external microphones are plugged in.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,30 @@ This interface enables a user to remotely teleoperate a Stretch robot through a 
 
 The interface is compatible with the Stretch RE1, RE2 and SE3. It currently only supports Ubuntu 22.04 and ROS2 Humble. Upgrade your operating system if necessary ([instructions](https://docs.hello-robot.com/0.3/installation/robot_install/)) and create/update the Stretch ROS2 Humble workspace ([instructions](https://docs.hello-robot.com/0.3/installation/ros_workspace/)). This will install all package dependencies and install the web teleop interface.
 
+## Audio configuration
+
+### Audio Devices
+
+For robot-to-operator audio streaming, the web interfaces uses the robot's system default microphone if one or more external microphones are plugged in, or the built-in robot microphone if no external microphones are plugged in.
+
+For operator-to-robot text-to-speech, the web interface uses the system default speaker.
+
+However, note the system defaults can change when you (un)plug audio devices (e.g., sometimes (un)plugging a mic can cause the system default speaker to change). Thus, it is best practice to always check.
+
+In the below instructions,  replace `<sink/source>` with `sink` for a speaker and `source` for a microphone. Note that this won't work if you're using X-11 forwarding:
+
+1. List all speakers/microphones: `pactl list short <sink/source>s`
+1. Get the default: `pactl get-default-<sink/source>`
+1. Set the default: `pactl set-default-<sink/source> <device-name>` where `<device-name>` is one of the names listed from the above command.
+   1. The built-in default speaker will be called something like `alsa_output.pci-0000_00_1f.3.analog-stereo`, and the built-in default mic will be called something like `alsa_input.usb-SEEED_ReSpeaker_4_Mic_Array__UAC1.0_-00.multichannel-input`.
+
+### Audio volume/gain
+
+1. To unmute the speaker: `amixer set 'Master unmute`
+1. To set the speaker volume to 100%: `amixer sset 'Master' 100%` (Note that there is also a physical volume knob on the head of the Stretch3 that must be turned up.)
+1. To unmute the mic: `amixer set 'Capture' cap`
+1. To set the mic gain to 100%: `amixer sset 'Capture' 100%`
+
 ## Installing Beta Teleop Cameras
 
 To install the Beta teleop cameras, plug one camera in and run the following command:

--- a/configure_audio.sh
+++ b/configure_audio.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# Usage: ./configure_audio.sh -s <speaker_name> -m <mic_name>
+#
+# To get a list of valid speaker names, run:
+#     pactl list short sinks
+# To get a list of valid microphone names, run:
+#     pactl list short sources
+# Note that with a microphone, there is no need to specify a device name if there is
+# only one external mic plugged in; that one will **always** be prioritized over the
+# robot's built-in microphone. The only way to use the robot's built-in microphone
+# is to disconnect all external microphones.
+SPEAKER_NAME="alsa_output.pci-0000_00_1f.3.analog-stereo"
+if getopts ":s:" opt && [[ $opt == "s" ]]; then
+    SPEAKER_NAME="$OPTARG"
+fi
+MIC_NAME=""
+if getopts ":m:" opt && [[ $opt == "m" ]]; then
+    MIC_NAME="$OPTARG"
+fi
+
+echo "Setting speaker to $SPEAKER_NAME"
+pactl set-default-sink $SPEAKER_NAME
+
+if [ ${#MIC_NAME} -gt 0 ]; then
+    echo "Setting microphone to $MIC_NAME"
+    pactl set-default-source $MIC_NAME
+fi
+
+echo "Unmuting the speaker and setting its volume to 100%"
+amixer set 'Master' unmute -q
+amixer sset 'Master' 100% -q
+
+echo "Unmuting the microphone and setting its gain to 100%"
+amixer set 'Capture' cap -q
+amixer sset 'Capture' 100% -q
+
+echo "Done configuring audio!"

--- a/src/pages/robot/tsx/audiostreams.tsx
+++ b/src/pages/robot/tsx/audiostreams.tsx
@@ -12,7 +12,7 @@ export class AudioStream extends React.Component<AudioStreamProps> {
 
   async start() {
     this.outputAudioStream = await navigator.mediaDevices.getUserMedia({
-      audio: true,
+      audio: true, // Will use the default system mic
       video: false,
     });
   }


### PR DESCRIPTION
# Description

#62 and  #64 added bi-directional audio capabilities to the web interface. However, this working is contingent on proper configuration of (possibly external) audio devices.

This PR adds README instructions for configuring audio devices, and adds a convenience bash script for configuring audio devices.

# Testing procedure

- [x] Have no external audio devices plugged in. Verify that the physical volume knob on the Stretch3's head is turned all the way up. Run `./configure_audio.sh` and then launch the interface. Verify both robot-to-operator audio streaming and operator-to-robot TTS work.
- [x] Plug in an external microphone. Run `./configure_audio.sh` and then launch the interface. Verify that robot-to-operator audio streaming uses the new mic, and that operator-to-robot TTS works.
- [x] Disconnect the above mic and plug in another external mic. Repeat the above test.

# Before opening a pull request

From the top-level of this repository, run:

- [ ] `pre-commit run --all-files`

# To merge

- [ ] `Squash & Merge`
