### PR TITLE
Complete the temp fix from #63

### DIFF
--- a/src/pages/operator/tsx/function_providers/FunctionProvider.tsx
+++ b/src/pages/operator/tsx/function_providers/FunctionProvider.tsx
@@ -77,6 +77,9 @@ export abstract class FunctionProvider {
         }, 150);
     }
 
+    // NOTE: When we undo this temp fix (of not stopping the
+    // trajectory client) we also need to undo it in robot.jsx
+    // `stopExecution()`.
     public stopCurrentAction(send_stop_command: boolean = false) {
         if (send_stop_command) FunctionProvider.remoteRobot?.stopTrajectory();
         if (this.activeVelocityAction) {

--- a/src/pages/robot/tsx/robot.tsx
+++ b/src/pages/robot/tsx/robot.tsx
@@ -927,10 +927,22 @@ export class Robot extends React.Component {
         this.trajectoryClient.createClient(this.poseGoal);
     }
 
-    stopExecution() {
-        this.stopTrajectoryClient();
-        this.stopMoveBaseClient();
-        this.stopMoveToPregraspClient();
+    // NOTE: When we undo this temp fix (of not stopping the
+    // trajectory client) we also need to undo it in FunctionProvider.jsx
+    // `stopCurrentAction()`.
+    // However, we should consider not stopping the trajectory client here,
+    // regardless, because:
+    //   (1) there is a race condition where ROS can receive the cancellation
+    //       request *after* the new goal, and thus cancel the new goal (e.g.,
+    //       this occurs often when toggling the tablet between portrait and
+    //       landscape mode);
+    //   (2) the trajectory client smoothly interpolates between goals anyway,
+    //       so there is no need to stop it.
+    // If we premanently don't stop the trajectory client here, then
+    // `stopExecution` should just be replaced with `stopAutonomousClients`.
+    stopExecution(stop_trajectory_client: boolean = false) {
+        if (stop_trajectory_client) this.stopTrajectoryClient();
+        this.stopAutonomousClients();
     }
 
     stopAutonomousClients() {


### PR DESCRIPTION
# Description

#63 temporarily fixed the wrist dropping issue by removing "all" commands to stop the trajectory client. However, it missed one command in `robot.tsx`. As a result of that, the wrist pitch still drops when toggling the tablet between portrait and landscape (likely amongst other commands). This PR addresses that oversight by also adding a flag to not run that command to stop the trajectory client.

# Testing procedure

- [x] **Verify the issue**: Pull on `master`, have your robot configured with the tablet tool, and launch the interface. Keep toggling the tablet between portrait and landscape, and verify that the wrist pitch drops.
- [x] **Verify the fix**: Pull on this branch, have your robot configured with the tablet tool, and launch the interface. Keep toggling the tablet between portrait and landscape, and verify that the wrist pitch **_does not_** drop.

# Before opening a pull request

From the top-level of this repository, run:

- [x] `pre-commit run --all-files`

# To merge

- [x] `Squash & Merge`
