### PR TITLE
Add a check for the specialized URDFs in the launchfile

### DIFF
--- a/launch/web_interface.launch.py
+++ b/launch/web_interface.launch.py
@@ -196,6 +196,23 @@ def generate_launch_description():
         stretch_has_nav_head_cam,
     )
 
+    # If the stretch tool has the configuration(s) that require the specialized URDFs
+    # (e.g., move-to-pregrasp, enabled with the dex wrist, requires the specialized URDFs),
+    # check if the specialized URDFs exist and raise an exception if they don't.
+    if stretch_tool == "eoa_wrist_dw3_tool_sg3":
+        specialized_urdf_path = os.path.join(
+            teleop_interface_package, "urdf", "stretch_base_rotation_ik.urdf"
+        )
+        if not os.path.exists(specialized_urdf_path):
+            raise FileNotFoundError(
+                "Could not find the specialized URDF, which is required for move-to-pregrasp, "
+                f"at {specialized_urdf_path}. Run the following:\n"
+                "    1. `colcon_cd stretch_web_teleop`\n"
+                "    2. `python3 prepare_specialized_urdf.py`\n"
+                "    3. `cd ~/ament_ws`\n"
+                "    4. `colcon build`"
+            )
+
     # Declare launch arguments
     params_file = DeclareLaunchArgument(
         "params",


### PR DESCRIPTION
Joint with [`stretch_install`#77](https://github.com/hello-robot/stretch_install/pull/77) and [`stretch_production_tools`#24](https://github.com/hello-robot/stretch_production_tools/pull/24).

Although [`stretch_install`#72](https://github.com/hello-robot/stretch_install/pull/72/files) changed `stretch_create_ament_workspace.sh` to run `prepare_specialized_urdf.py`, that won't actually work since the URDFs don't get generated until after that script is run. As discussed with @hello-fazil and @hello-vinitha , this PR (and its joint PRs, above):

1. Stops running `prepare_specialized_urdf.py` as part of creating the ROS2 workspace.
2. Instead, adds instructions to run that script as part of the Python SDK QC process.
3. Raises an exception in the web teleop launchfile if the URDFs don't exist, with instructions on how to create them.

# Testing

- [x] Delete the URDFs, rebuild your workspace, run `ros2 launch stretch_web_teleop web_interface.launch.py` and verify it fails and tells you how to generate the URDFs.
- [x] Follow the instructions in the message, re-run `ros2 launch stretch_web_teleop web_interface.launch.py`, and verify it succeds.