### PR TITLE
Gracefully handle case where gripper pointcloud has size 0

### DIFF
--- a/nodes/configure_video_streams.py
+++ b/nodes/configure_video_streams.py
@@ -762,6 +762,12 @@ class ConfigureVideoStreams(Node):
             )
             pcl_cloud_filtered = downsampler.filter()
         pc_in_camera_filtered = pcl_cloud_filtered.to_array()
+        if pc_in_camera_filtered.shape[0] == 0:
+            self.get_logger().debug(
+                "No points in the gripper's depth image. Skipping point cloud processing.",
+                throttle_duration_sec=1.0,
+            )
+            return image
 
         # Create the Aruco Detector
         if self.aruco_detector is None:
@@ -790,6 +796,11 @@ class ConfigureVideoStreams(Node):
                 aruco_center_pos[label] = deproject_pixel_to_pointcloud_point(
                     center[0], center[1], pc_in_camera_filtered, self.gripper_P
                 )
+                if aruco_center_pos[label] is None:
+                    self.get_logger().warn(
+                        f"Could not deproject the center of aruco marker {label}. Skipping point cloud processing."
+                    )
+                    return image
         if (
             "finger_left" not in aruco_center_pos
             or "finger_right" not in aruco_center_pos

--- a/stretch_web_teleop_helpers/conversions.py
+++ b/stretch_web_teleop_helpers/conversions.py
@@ -214,7 +214,7 @@ def deproject_pixel_to_point(
 
 def deproject_pixel_to_pointcloud_point(
     u: int, v: int, pointcloud: npt.NDArray[np.float32], proj: npt.NDArray[np.float32]
-) -> Tuple[float, float, float]:
+) -> Optional[Tuple[float, float, float]]:
     """
     Deproject the clicked pixel to the 3D coordinates of the closest point within the pointcloud.
 
@@ -227,8 +227,13 @@ def deproject_pixel_to_pointcloud_point(
 
     Returns
     -------
-    Tuple[float, float, float]: The 3D coordinates of the clicked point.
+    Optional[Tuple[float, float, float]]: The 3D coordinates of the clicked point, or None
+        if the pointcloud is empty.
     """
+    # Check if the pointcloud is empty
+    if pointcloud.shape[0] == 0:
+        return None
+
     # Get the ray from the camera origin to the clicked point
     ray_dir = np.linalg.pinv(proj)[:3, :] @ np.array([u, v, 1])
     ray_dir /= np.linalg.norm(ray_dir)


### PR DESCRIPTION
# Description

If the gripper's pointcloud had depth 0 while gripper depth AR were enabled , it would crash. This PR addresses that.

# Testing procedure

- [x] **Verify the fix**: Before the changed code in `configure_video_streams` and `move_to_pregrasp`, add lines of code hardcoding the pointcloud size to 0 (e.g., `np.zeros((0,3), dtype=np.uint16)`). Launch the interface, toggle on gripper depth AR, try move-to-pregrasp, verify that the node doesn't crash.
- [x] Remove those lines, try the above two features, verify that they work.

# Before opening a pull request

From the top-level of this repository, run:

- [ ] `pre-commit run --all-files`

# To merge

- [ ] `Squash & Merge`
