### PR TITLE
Update show tablet package name

### DIFF
--- a/launch/web_interface.launch.py
+++ b/launch/web_interface.launch.py
@@ -558,21 +558,21 @@ def generate_launch_description():
 
     if stretch_tool == "eoa_wrist_dw3_tool_tablet_12in":
         detect_body_landmarks_node = Node(
-            package="stretch_tablet",
+            package="stretch_show_tablet",
             executable="detect_body_landmarks",
             output="screen",
         )
         ld.add_action(detect_body_landmarks_node)
 
         plan_tablet_pose_node = Node(
-            package="stretch_tablet",
+            package="stretch_show_tablet",
             executable="plan_tablet_pose_service",
             output="screen",
         )
         ld.add_action(plan_tablet_pose_node)
 
         show_tablet_node = Node(
-            package="stretch_tablet",
+            package="stretch_show_tablet",
             executable="show_tablet_server",
             output="screen",
         )

--- a/src/pages/robot/tsx/robot.tsx
+++ b/src/pages/robot/tsx/robot.tsx
@@ -550,7 +550,7 @@ export class Robot extends React.Component {
         this.showTabletClient = new ROSLIB.ActionHandle({
             ros: this.ros,
             name: showTabletActionName,
-            actionType: "stretch_tablet_interfaces/action/ShowTablet",
+            actionType: "stretch_show_tablet_interfaces/action/ShowTablet",
         });
     }
 


### PR DESCRIPTION
# Description

Changes references to the `stretch_show_tablet` packages to reflect new naming convention.

# Testing procedure

Rebuild ROS2 workspace, run web teleop, and try to show someone the tablet.

# Before opening a pull request

From the top-level of this repository, run:

- [ ] `pre-commit run --all-files`

# To merge

- [ ] `Squash & Merge`
