### PR TITLE
Joint Selection for Movement Recorder

### DIFF
--- a/src/pages/operator/tsx/function_providers/MovementRecorderFunctionProvider.tsx
+++ b/src/pages/operator/tsx/function_providers/MovementRecorderFunctionProvider.tsx
@@ -25,7 +25,9 @@ export class MovementRecorderFunctionProvider extends FunctionProvider {
                     head: boolean,
                     arm: boolean,
                     lift: boolean,
-                    wrist: boolean,
+                    wrist_roll: boolean,
+                    wrist_pitch: boolean,
+                    wrist_yaw: boolean,
                     gripper: boolean,
                 ) => {
                     let prevJoint: ValidJoints | undefined;
@@ -37,7 +39,9 @@ export class MovementRecorderFunctionProvider extends FunctionProvider {
                                 head,
                                 arm,
                                 lift,
-                                wrist,
+                                wrist_roll,
+                                wrist_pitch,
+                                wrist_yaw,
                                 gripper,
                             );
                         const prevPose =

--- a/src/pages/operator/tsx/layout_components/CameraView.tsx
+++ b/src/pages/operator/tsx/layout_components/CameraView.tsx
@@ -187,7 +187,7 @@ export const CameraView = (props: CustomizableComponentProps) => {
             console.log("scaled x", scaled_x, "scaled y", scaled_y);
             // underVideoFunctionProvider.provideFunctions(
             //   UnderVideoButton.MoveToPregrasp,
-            // ).onClick!(scaled_x, scaled_y);
+            // ).onClick!(scaled_x, scaled_y);add
         }
     }
 

--- a/src/pages/operator/tsx/layout_components/CameraView.tsx
+++ b/src/pages/operator/tsx/layout_components/CameraView.tsx
@@ -47,8 +47,8 @@ import { CheckToggleButton } from "../basic_components/CheckToggleButton";
 import { AccordionSelect } from "../basic_components/AccordionSelect";
 import "operator/css/CameraView.css";
 import AddIcon from "@mui/icons-material/Add";
-import ArrowRightIcon from "@mui/icons-material/ArrowRight";
 import CancelIcon from "@mui/icons-material/Cancel";
+import ArrowRightIcon from "@mui/icons-material/ArrowRight";
 import PlayCircleFilledIcon from "@mui/icons-material/PlayCircleFilled";
 
 /**

--- a/src/pages/operator/tsx/layout_components/CameraView.tsx
+++ b/src/pages/operator/tsx/layout_components/CameraView.tsx
@@ -48,7 +48,6 @@ import { AccordionSelect } from "../basic_components/AccordionSelect";
 import "operator/css/CameraView.css";
 import AddIcon from "@mui/icons-material/Add";
 import CancelIcon from "@mui/icons-material/Cancel";
-import ArrowRightIcon from "@mui/icons-material/ArrowRight";
 import PlayCircleFilledIcon from "@mui/icons-material/PlayCircleFilled";
 
 /**

--- a/src/pages/operator/tsx/layout_components/MovementRecorder.tsx
+++ b/src/pages/operator/tsx/layout_components/MovementRecorder.tsx
@@ -105,11 +105,11 @@ export const MovementRecorder = (props: {
 
         function handleAccept() {
             functions.Record(head, arm, lift, wrist, gripper);
-            setHead(true);
-            setArm(true);
-            setLift(true);
-            setWrist(true);
-            setGripper(true);
+            setHead(false);
+            setArm(false);
+            setLift(false);
+            setWrist(false);
+            setGripper(false);
         }
 
         return (

--- a/src/pages/operator/tsx/layout_components/MovementRecorder.tsx
+++ b/src/pages/operator/tsx/layout_components/MovementRecorder.tsx
@@ -311,7 +311,7 @@ export const MovementRecorder = (props: {
                         }}
                     >
                         <span hidden={props.hideLabels}>Play</span>
-                        <PlayCircle/>
+                        <PlayCircle />
                     </button>
                 </Tooltip>
                 <Tooltip
@@ -354,7 +354,7 @@ export const MovementRecorder = (props: {
                         }}
                     >
                         <span hidden={props.hideLabels}>Delete</span>
-                        <DeleteForeverIcon/>
+                        <DeleteForeverIcon />
                     </button>
                 </Tooltip>
             </div>
@@ -397,7 +397,7 @@ export const MovementRecorder = (props: {
                         }
                     }}
                 >
-                    <PlayCircle/>
+                    <PlayCircle />
                     <i>Play</i>
                 </div>
             </div>

--- a/src/pages/operator/tsx/layout_components/MovementRecorder.tsx
+++ b/src/pages/operator/tsx/layout_components/MovementRecorder.tsx
@@ -311,7 +311,7 @@ export const MovementRecorder = (props: {
                         }}
                     >
                         <span hidden={props.hideLabels}>Play</span>
-                        <PlayCircle />
+                        <PlayCircle/>
                     </button>
                 </Tooltip>
                 <Tooltip
@@ -354,7 +354,7 @@ export const MovementRecorder = (props: {
                         }}
                     >
                         <span hidden={props.hideLabels}>Delete</span>
-                        <DeleteForeverIcon />
+                        <DeleteForeverIcon/>
                     </button>
                 </Tooltip>
             </div>
@@ -397,7 +397,7 @@ export const MovementRecorder = (props: {
                         }
                     }}
                 >
-                    <PlayCircle />
+                    <PlayCircle/>
                     <i>Play</i>
                 </div>
             </div>

--- a/src/pages/operator/tsx/layout_components/MovementRecorder.tsx
+++ b/src/pages/operator/tsx/layout_components/MovementRecorder.tsx
@@ -26,7 +26,13 @@ export enum MovementRecorderFunction {
 }
 
 export interface MovementRecorderFunctions {
-    Record: () => void;
+    Record: (
+        head: boolean,
+        arm: boolean,
+        lift: boolean,
+        wrist: boolean,
+        gripper: boolean,
+    ) => void;
     SaveRecording: (name: string) => void;
     StopRecording: () => void;
     SavedRecordingNames: () => string[];
@@ -42,7 +48,13 @@ export const MovementRecorder = (props: {
     let functions: MovementRecorderFunctions = {
         Record: movementRecorderFunctionProvider.provideFunctions(
             MovementRecorderFunction.Record,
-        ) as () => void,
+        ) as (
+            head: boolean,
+            arm: boolean,
+            lift: boolean,
+            wrist: boolean,
+            gripper: boolean,
+        ) => void,
         SaveRecording: movementRecorderFunctionProvider.provideFunctions(
             MovementRecorderFunction.SaveRecording,
         ) as (name: string) => void,
@@ -73,11 +85,109 @@ export const MovementRecorder = (props: {
         functions.SavedRecordingNames(),
     );
     const [selectedIdx, setSelectedIdx] = React.useState<number>();
+    const [showJointSelectionModal, setShowJointSelectionModal] =
+        useState<boolean>(false);
     const [showSaveRecordingModal, setShowSaveRecordingModal] =
         useState<boolean>(false);
     const [isRecording, setIsRecording] = React.useState<boolean>(
         props.isRecording ? props.isRecording : false,
     );
+
+    const JointSelectionModal = (props: {
+        setShow: (show: boolean) => void;
+        show: boolean;
+    }) => {
+        const [head, setHead] = React.useState<boolean>(true);
+        const [arm, setArm] = React.useState<boolean>(true);
+        const [lift, setLift] = React.useState<boolean>(true);
+        const [wrist, setWrist] = React.useState<boolean>(true);
+        const [gripper, setGripper] = React.useState<boolean>(true);
+
+        function handleAccept() {
+            functions.Record(head, arm, lift, wrist, gripper);
+            setHead(true);
+            setArm(true);
+            setLift(true);
+            setWrist(true);
+            setGripper(true);
+        }
+
+        return (
+            <PopupModal
+                setShow={props.setShow}
+                show={props.show}
+                onAccept={handleAccept}
+                onCancel={() => functions.StopRecording()}
+                id="save-recording-modal"
+                acceptButtonText="Save"
+                size={isMobile ? "small" : "large"}
+                mobile={isMobile}
+            >
+                {/* <label htmlFor="new-recoding-name"><b>Save Recording</b></label>
+                <hr/> */}
+                <div className="joint-checkbox">
+                    <label>Select the joints to record:</label>
+                </div>
+                <ul className="checkbox">
+                    <li>
+                        <input
+                            type="checkbox"
+                            id="head"
+                            name="save-head-pose"
+                            value="Head"
+                            defaultChecked={head}
+                            onChange={(e) => setHead(e.target.checked)}
+                        />
+                        <label>Head</label>
+                    </li>
+                    <li>
+                        <input
+                            type="checkbox"
+                            id="arm"
+                            name="save-arm-pose"
+                            value="Arm"
+                            defaultChecked={arm}
+                            onChange={(e) => setArm(e.target.checked)}
+                        />
+                        <label>Arm</label>
+                    </li>
+                    <li>
+                        <input
+                            type="checkbox"
+                            id="lift"
+                            name="save-lift-pose"
+                            value="Lift"
+                            defaultChecked={lift}
+                            onChange={(e) => setLift(e.target.checked)}
+                        />
+                        <label>Lift</label>
+                    </li>
+                    <li>
+                        <input
+                            type="checkbox"
+                            id="wrist"
+                            name="save-wrist-pose"
+                            value="Wrist"
+                            defaultChecked={wrist}
+                            onChange={(e) => setWrist(e.target.checked)}
+                        />
+                        <label>Wrist</label>
+                    </li>
+                    <li>
+                        <input
+                            type="checkbox"
+                            id="gripper"
+                            name="save-gripper-pose"
+                            value="Gripper"
+                            defaultChecked={gripper}
+                            onChange={(e) => setGripper(e.target.checked)}
+                        />
+                        <label>Gripper</label>
+                    </li>
+                </ul>
+            </PopupModal>
+        );
+    };
 
     const SaveRecordingModal = (props: {
         setShow: (show: boolean) => void;
@@ -124,15 +234,15 @@ export const MovementRecorder = (props: {
         );
     };
 
-    useEffect(() => {
-        if (props.isRecording == undefined) {
-            return;
-        } else if (props.isRecording) {
-            functions.Record();
-        } else {
-            setShowSaveRecordingModal(true);
-        }
-    }, [props.isRecording]);
+    // useEffect(() => {
+    //     if (props.isRecording == undefined) {
+    //         return;
+    //     } else if (props.isRecording) {
+    //         functions.Record();
+    //     } else {
+    //         setShowSaveRecordingModal(true);
+    //     }
+    // }, [props.isRecording]);
 
     if (props.globalRecord !== undefined && !props.globalRecord)
         return (
@@ -175,7 +285,7 @@ export const MovementRecorder = (props: {
                         onClick={() => {
                             if (!isRecording) {
                                 setIsRecording(true);
-                                functions.Record();
+                                setShowJointSelectionModal(true);
                             } else {
                                 setIsRecording(false);
                                 setShowSaveRecordingModal(true);
@@ -210,6 +320,10 @@ export const MovementRecorder = (props: {
                     </button>
                 </Tooltip>
             </div>
+            <JointSelectionModal
+                setShow={setShowJointSelectionModal}
+                show={showJointSelectionModal}
+            />
             <SaveRecordingModal
                 setShow={setShowSaveRecordingModal}
                 show={showSaveRecordingModal}
@@ -249,6 +363,10 @@ export const MovementRecorder = (props: {
                     <i>Play</i>
                 </div>
             </div>
+            <JointSelectionModal
+                setShow={setShowJointSelectionModal}
+                show={showJointSelectionModal}
+            />
             <SaveRecordingModal
                 setShow={setShowSaveRecordingModal}
                 show={showSaveRecordingModal}

--- a/src/pages/operator/tsx/layout_components/MovementRecorder.tsx
+++ b/src/pages/operator/tsx/layout_components/MovementRecorder.tsx
@@ -30,7 +30,9 @@ export interface MovementRecorderFunctions {
         head: boolean,
         arm: boolean,
         lift: boolean,
-        wrist: boolean,
+        wrist_roll: boolean,
+        wrist_pitch: boolean,
+        wrist_yaw: boolean,
         gripper: boolean,
     ) => void;
     SaveRecording: (name: string) => void;
@@ -52,7 +54,9 @@ export const MovementRecorder = (props: {
             head: boolean,
             arm: boolean,
             lift: boolean,
-            wrist: boolean,
+            wrist_roll: boolean,
+            wrist_pitch: boolean,
+            wrist_yaw: boolean,
             gripper: boolean,
         ) => void,
         SaveRecording: movementRecorderFunctionProvider.provideFunctions(
@@ -97,18 +101,30 @@ export const MovementRecorder = (props: {
         setShow: (show: boolean) => void;
         show: boolean;
     }) => {
-        const [head, setHead] = React.useState<boolean>(true);
-        const [arm, setArm] = React.useState<boolean>(true);
-        const [lift, setLift] = React.useState<boolean>(true);
-        const [wrist, setWrist] = React.useState<boolean>(true);
-        const [gripper, setGripper] = React.useState<boolean>(true);
+        const [head, setHead] = React.useState<boolean>(false);
+        const [arm, setArm] = React.useState<boolean>(false);
+        const [lift, setLift] = React.useState<boolean>(false);
+        const [wristRoll, setWristRoll] = React.useState<boolean>(false);
+        const [wristPitch, setWristPitch] = React.useState<boolean>(false);
+        const [wristYaw, setWristYaw] = React.useState<boolean>(false);
+        const [gripper, setGripper] = React.useState<boolean>(false);
 
         function handleAccept() {
-            functions.Record(head, arm, lift, wrist, gripper);
+            functions.Record(
+                head,
+                arm,
+                lift,
+                wristRoll,
+                wristPitch,
+                wristYaw,
+                gripper,
+            );
             setHead(false);
             setArm(false);
             setLift(false);
-            setWrist(false);
+            setWristRoll(false);
+            setWristPitch(false);
+            setWristYaw(false);
             setGripper(false);
         }
 
@@ -165,13 +181,35 @@ export const MovementRecorder = (props: {
                     <li>
                         <input
                             type="checkbox"
-                            id="wrist"
-                            name="save-wrist-pose"
-                            value="Wrist"
-                            defaultChecked={wrist}
-                            onChange={(e) => setWrist(e.target.checked)}
+                            id="wristRoll"
+                            name="save-wrist-roll-pose"
+                            value="Wrist Roll"
+                            defaultChecked={wristRoll}
+                            onChange={(e) => setWristRoll(e.target.checked)}
                         />
-                        <label>Wrist</label>
+                        <label>Wrist Roll</label>
+                    </li>
+                    <li>
+                        <input
+                            type="checkbox"
+                            id="wristPitch"
+                            name="save-wrist-pitch-pose"
+                            value="Wrist Pitch"
+                            defaultChecked={wristPitch}
+                            onChange={(e) => setWristPitch(e.target.checked)}
+                        />
+                        <label>Wrist Pitch</label>
+                    </li>
+                    <li>
+                        <input
+                            type="checkbox"
+                            id="wristYaw"
+                            name="save-wrist-yaw-pose"
+                            value="Wrist Yaw"
+                            defaultChecked={wristYaw}
+                            onChange={(e) => setWristYaw(e.target.checked)}
+                        />
+                        <label>Wrist Yaw</label>
                     </li>
                     <li>
                         <input

--- a/src/pages/operator/tsx/static_components/Sidebar.tsx
+++ b/src/pages/operator/tsx/static_components/Sidebar.tsx
@@ -576,7 +576,13 @@ const ComponentProviderTab = (props: ComponentProviderTabProps) => {
         <div className="provider-tab" key={props.type}>
             <button
                 onClick={clickExpand}
-                className={tabActive && !props.ids ? "active" : props.expanded}
+                className={
+                    tabActive && !props.ids
+                        ? "active"
+                        : props.expanded
+                          ? "expanded"
+                          : ""
+                }
             >
                 {props.ids ? (
                     props.expanded ? (

--- a/src/pages/operator/tsx/static_components/Sidebar.tsx
+++ b/src/pages/operator/tsx/static_components/Sidebar.tsx
@@ -576,13 +576,7 @@ const ComponentProviderTab = (props: ComponentProviderTabProps) => {
         <div className="provider-tab" key={props.type}>
             <button
                 onClick={clickExpand}
-                className={
-                    tabActive && !props.ids
-                        ? "active"
-                        : props.expanded
-                          ? "expanded"
-                          : ""
-                }
+                className={tabActive && !props.ids ? "active" : props.expanded}
             >
                 {props.ids ? (
                     props.expanded ? (

--- a/src/shared/remoterobot.tsx
+++ b/src/shared/remoterobot.tsx
@@ -425,7 +425,9 @@ class RobotSensors extends React.Component {
         head: boolean,
         arm: boolean,
         lift: boolean,
-        wrist: boolean,
+        wrist_roll: boolean,
+        wrist_pitch: boolean,
+        wrist_yaw: boolean,
         gripper: boolean,
     ): RobotPose {
         let filteredPose: RobotPose = {};
@@ -439,11 +441,15 @@ class RobotSensors extends React.Component {
         if (lift) {
             filteredPose["joint_lift"] = this.robotPose["joint_lift"];
         }
-        if (wrist) {
+        if (wrist_roll) {
             filteredPose["joint_wrist_roll"] =
                 this.robotPose["joint_wrist_roll"];
+        }
+        if (wrist_pitch) {
             filteredPose["joint_wrist_pitch"] =
                 this.robotPose["joint_wrist_pitch"];
+        }
+        if (wrist_yaw) {
             filteredPose["joint_wrist_yaw"] = this.robotPose["joint_wrist_yaw"];
         }
         if (gripper) {

--- a/src/shared/remoterobot.tsx
+++ b/src/shared/remoterobot.tsx
@@ -421,24 +421,34 @@ class RobotSensors extends React.Component {
     /**
      * @returns current robot pose
      */
-    getRobotPose(head: boolean, gripper: boolean, arm: boolean): RobotPose {
+    getRobotPose(
+        head: boolean,
+        arm: boolean,
+        lift: boolean,
+        wrist: boolean,
+        gripper: boolean,
+    ): RobotPose {
         let filteredPose: RobotPose = {};
         if (head) {
             filteredPose["joint_head_tilt"] = this.robotPose["joint_head_tilt"];
             filteredPose["joint_head_pan"] = this.robotPose["joint_head_pan"];
         }
-        if (gripper) {
+        if (arm) {
+            filteredPose["wrist_extension"] = this.robotPose["wrist_extension"];
+        }
+        if (lift) {
+            filteredPose["joint_lift"] = this.robotPose["joint_lift"];
+        }
+        if (wrist) {
             filteredPose["joint_wrist_roll"] =
                 this.robotPose["joint_wrist_roll"];
             filteredPose["joint_wrist_pitch"] =
                 this.robotPose["joint_wrist_pitch"];
             filteredPose["joint_wrist_yaw"] = this.robotPose["joint_wrist_yaw"];
+        }
+        if (gripper) {
             filteredPose["joint_gripper_finger_left"] =
                 this.robotPose["joint_gripper_finger_left"];
-        }
-        if (arm) {
-            filteredPose["joint_lift"] = this.robotPose["joint_lift"];
-            filteredPose["wrist_extension"] = this.robotPose["wrist_extension"];
         }
         return filteredPose;
     }


### PR DESCRIPTION
# Description

This PR adds an additional modal to movement recorder that allows the operator to select the joints to record movement for prior to starting the recording. 

# Testing procedure

\[TODO: describe, in-detail, how you tested this. The procedure must be detailed enough for the reviewer(s) to recreate it.\]

# Before opening a pull request

From the top-level of this repository, run:

- [ ] `pre-commit run --all-files`

# To merge

- [ ] `Squash & Merge`
