### PR TITLE
Only launch lidar if needed

### DIFF
--- a/launch/web_interface.launch.py
+++ b/launch/web_interface.launch.py
@@ -496,7 +496,9 @@ def generate_launch_description():
                 }.items(),
             ),
             IncludeLaunchDescription(
-                PythonLaunchDescriptionSource([stretch_core_path, "/launch/rplidar.launch.py"])
+                PythonLaunchDescriptionSource(
+                    [stretch_core_path, "/launch/rplidar.launch.py"]
+                )
             ),
         ],
     )

--- a/launch/web_interface.launch.py
+++ b/launch/web_interface.launch.py
@@ -474,11 +474,6 @@ def generate_launch_description():
         )
         ld.add_action(configure_video_streams_node)
 
-    rplidar_launch = IncludeLaunchDescription(
-        PythonLaunchDescriptionSource([stretch_core_path, "/launch/rplidar.launch.py"])
-    )
-    ld.add_action(rplidar_launch)
-
     navigation_bringup_launch = GroupAction(
         condition=LaunchConfigurationNotEquals("map_yaml", ""),
         actions=[
@@ -499,7 +494,10 @@ def generate_launch_description():
                     "params_file": LaunchConfiguration("nav2_params_file"),
                     "use_rviz": "false",
                 }.items(),
-            )
+            ),
+            IncludeLaunchDescription(
+                PythonLaunchDescriptionSource([stretch_core_path, "/launch/rplidar.launch.py"])
+            ),
         ],
     )
     ld.add_action(navigation_bringup_launch)


### PR DESCRIPTION
# Description

This small PR changes the condition on which the RPLidar's driver is launched (and starts spinning the unit). Instead of always launching the driver, it is only launched with Nav2 is also being launched. Given that the RPLidar is used to provide a sensor measurement for the localization stack within Nav2, it makes sense to leave it out if we aren't using Nav2.

# Testing procedure

1. In your Ament workspace, go to Stretch Web Teleop and switch to the `bugfix/unnecessary_lidar` branch.
2. `colcon build` the Ament workspace as usual
3. Launch the interface with no map. You'll notice the lidar **does not** start to spin.
4. Launch the interface with a map. You'll notice the lidar **does** start to spin.

# Before opening a pull request

From the top-level of this repository, run:

- [x] `pre-commit run --all-files`

# To merge

- [ ] `Squash & Merge`
