### PR TITLE
Don't run Github Action on draft PRs

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -6,6 +6,7 @@ on:
       - main
       - master
   pull_request:
+    types: [review_requested, ready_for_review]
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
# Description

This change prevents the pre-commit Github Action from running on draft PRs. This will save us money and prevent our Github Action "minutes" budget from being unnecessarily used up. This solution was [found here](https://github.com/orgs/community/discussions/25722#discussioncomment-3248907).

# Testing procedure

I've created a [test repo/PR](https://github.com/hello-robot/ghaction_ready_prs_only/pull/1) to ensure this works. When a draft PR is raised and commits are added (commits "run prettier" and "Bogus Change" below), the action doesn't trigger. After marking the PR as ready for review or requesting a reviewer (commit "Trigger CI on this commit"), the action triggers.

![image](https://github.com/user-attachments/assets/889a84cc-1a8f-41a8-8afa-150c3d8b6c0f)

# To merge

- [ ] `Squash & Merge`
