### PR TITLE
Create tsconfig to fix module resolution in VS Code

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,14 @@
+{
+    "compilerOptions": {
+      "module": "NodeNext",
+      "moduleResolution": "NodeNext",
+      "esModuleInterop": true,
+      "jsx": "react",
+      "baseUrl": ".",
+      "paths": {
+        "shared/*": ["src/shared/*"],
+        "operator/*": ["src/pages/operator/*"],
+        "robot/*": ["src/pages/robot/*"],
+      },
+    }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,14 +1,14 @@
 {
     "compilerOptions": {
-      "module": "NodeNext",
-      "moduleResolution": "NodeNext",
-      "esModuleInterop": true,
-      "jsx": "react",
-      "baseUrl": ".",
-      "paths": {
-        "shared/*": ["src/shared/*"],
-        "operator/*": ["src/pages/operator/*"],
-        "robot/*": ["src/pages/robot/*"],
-      },
+        "module": "NodeNext",
+        "moduleResolution": "NodeNext",
+        "esModuleInterop": true,
+        "jsx": "react",
+        "baseUrl": ".",
+        "paths": {
+            "shared/*": ["src/shared/*"],
+            "operator/*": ["src/pages/operator/*"],
+            "robot/*": ["src/pages/robot/*"]
+        }
     }
 }


### PR DESCRIPTION
# Description

When developing on Web Teleop in VS Code, the IDE will show many "failure to resolve module" errors when importing a module from the "shared/" directory. This PR introduces a `tsconfig.json` file, which tells VS code about these aliases and stops the errors from appearing.

![Screenshot from 2024-10-03 13-50-50](https://github.com/user-attachments/assets/9072d7f7-29db-427c-8187-881a9fb57e20)

# Testing procedure

Open Web Teleop in VS Code on the main branch and look at the imports of any file. Then checkout this branch and do the same. The red squiggles should be gone.

# Before opening a pull request

From the top-level of this repository, run:

- [ ] `pre-commit run --all-files`

# To merge

- [ ] `Squash & Merge`
