### PR TITLE
Fix pre-commit GH Action not running on PR updates

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -6,7 +6,7 @@ on:
       - main
       - master
   pull_request:
-    types: [review_requested, ready_for_review]
+    types: [opened, reopened, synchronize, review_requested, ready_for_review]
   workflow_dispatch:
 
 concurrency:
@@ -19,6 +19,7 @@ env:
 jobs:
   pre-commit:
     runs-on: ubuntu-latest
+    if: ${{ !github.event.pull_request.draft }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5


### PR DESCRIPTION
# Description

In PR #104, we changed the pre-commit GH Action to only trigger on "ready_to_review" events. This led to weird behavior where subsequent commits aren't triggering the action. This PR fixes it by triggering more broadly and then filtering out draft PRs. See https://github.com/reviewdog/action-eslint/issues/29#issuecomment-985939887 for more details.

# Before opening a pull request

From the top-level of this repository, run:

- [ ] `pre-commit run --all-files`

# To merge

- [ ] `Squash & Merge`
