### PR TITLE
Improved scripts

### DIFF
--- a/launch_interface.sh
+++ b/launch_interface.sh
@@ -48,7 +48,7 @@ if [ $? -ne 0 ]; then
     echo_failure_help
 fi
 
-echo ""
+# echo ""
 cd $HOME/ament_ws/src/stretch_web_teleop
 ./start_web_server_and_robot_browser.sh -l $logdir $FIREBASE |& tee $logfile_node
 if [ $? -ne 0 ]; then
@@ -59,9 +59,9 @@ zip -r $logzip $logdir/ > /dev/null
 
 echo ""
 echo "#############################################"
-echo "DONE! WEB TELEOP IS UP."
+echo "DONE! WEB TELEOP IS UP!"
 echo "Visit the URL(s) below to see the web interface:"
-if [ -z $FIREBASE ]; then
+if [ "$FIREBASE" = "-f" ]; then
     echo "https://web.hello-robot.com/"
 else
     echo "https://localhost/operator"

--- a/start_robot_browser.js
+++ b/start_robot_browser.js
@@ -27,12 +27,6 @@ if (process.argv.length > 2) {
     const browser = await firefox.launch({
         headless: true, // default is true
         defaultViewport: null,
-        // NOTE: I (Amal) believe the below args are unnecessary now that we've switched from Chromium to Firefox.
-        args: [
-            "--use-fake-ui-for-media-stream", //gives permission to access the robot's cameras and microphones (cleaner and simpler than changing the user directory)
-            "--disable-features=WebRtcHideLocalIpsWithMdns", // Disables mDNS hostname use in local network P2P discovery. Necessary for enterprise networks that don't forward mDNS traffic
-            "--ignore-certificate-errors",
-        ],
         firefoxUserPrefs: {
             "permissions.default.microphone": 1, // Give permission to access the robot's microphone
         },

--- a/start_ros2.sh
+++ b/start_ros2.sh
@@ -40,7 +40,7 @@ source ~/ament_ws/install/setup.bash &>> $REDIRECT_LOGFILE
 source /usr/share/colcon_cd/function/colcon_cd.sh &>> $REDIRECT_LOGFILE
 
 echo "Freeing robot process..."
-/usr/bin/python3 $HOME/.local/bin/stretch_free_robot_process.py; &>> $REDIRECT_LOGFILE
+/usr/bin/python3 $HOME/.local/bin/stretch_free_robot_process.py &>> $REDIRECT_LOGFILE
 
 echo "Stopping previous instances..."
 ./stop_interface.sh &>> $REDIRECT_LOGFILE

--- a/start_ros2.sh
+++ b/start_ros2.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+set -e
+
+REDIRECT_LOGDIR="$HOME/stretch_user/log/web_teleop"
+mkdir -p $REDIRECT_LOGDIR
+while getopts l:m:t: opt; do
+    case $opt in
+        l)
+            # Usage: ./start_ros2.sh -l /tmp/some_folder
+            if [[ -d $OPTARG ]]; then
+                REDIRECT_LOGDIR=$OPTARG
+            fi
+            ;;
+        m)
+            # Usage: ./start_ros2.sh -m $HELLO_FLEET_PATH/maps/<map_name>.yaml
+            if [[ -f $OPTARG ]]; then
+                echo "Setting map..."
+                MAP_ARG="map_yaml:=$OPTARG"
+            fi
+            ;;
+        t)
+            # Usage: ./start_ros2.sh -t pyttsx3
+            echo "Setting tts engine..."
+            TTS_ARG="tts_engine:=$OPTARG"
+            ;;
+    esac
+done
+REDIRECT_LOGFILE="$REDIRECT_LOGDIR/start_ros2.`date '+%Y%m%d%H%M'`_redirected.txt"
+echo "Arguments:" &>> $REDIRECT_LOGFILE
+echo "-l $REDIRECT_LOGDIR" &>> $REDIRECT_LOGFILE
+echo "-m $MAP_ARG" &>> $REDIRECT_LOGFILE
+echo "-t $TTS_ARG" &>> $REDIRECT_LOGFILE
+
+echo "Setup environment..."
+. /etc/hello-robot/hello-robot.conf
+export HELLO_FLEET_ID HELLO_FLEET_ID
+export HELLO_FLEET_PATH=$HOME/stretch_user
+source /opt/ros/humble/setup.bash &>> $REDIRECT_LOGFILE
+source ~/ament_ws/install/setup.bash &>> $REDIRECT_LOGFILE
+source /usr/share/colcon_cd/function/colcon_cd.sh &>> $REDIRECT_LOGFILE
+
+echo "Freeing robot process..."
+/usr/bin/python3 $HOME/.local/bin/stretch_free_robot_process.py; &>> $REDIRECT_LOGFILE
+
+echo "Stopping previous instances..."
+./stop_interface.sh &>> $REDIRECT_LOGFILE
+
+echo "Reload USB bus..."
+sudo udevadm control --reload-rules && sudo udevadm trigger &>> $REDIRECT_LOGFILE
+
+echo "Start ROS2..."
+sleep 2;
+screen -dm -S "web_teleop_ros" ros2 launch stretch_web_teleop web_interface.launch.py $MAP_ARG $TTS_ARG &>> $REDIRECT_LOGFILE
+sleep 3;

--- a/start_ros2.sh
+++ b/start_ros2.sh
@@ -31,6 +31,12 @@ echo "-l $REDIRECT_LOGDIR" &>> $REDIRECT_LOGFILE
 echo "-m $MAP_ARG" &>> $REDIRECT_LOGFILE
 echo "-t $TTS_ARG" &>> $REDIRECT_LOGFILE
 
+if [[ -z `nmcli -t -f DEVICE c show --active | grep wlo1` ]]; then
+    echo "Not connected to Wifi. Starting Wifi-Connect..."
+    echo "Please connect to $HOSTNAME wifi and provide your home network's credentials"
+    sudo wifi-connect -s $HOSTNAME &>> $REDIRECT_LOGFILE
+fi
+
 echo "Setup environment..."
 . /etc/hello-robot/hello-robot.conf
 export HELLO_FLEET_ID HELLO_FLEET_ID

--- a/start_web_server_and_robot_browser.sh
+++ b/start_web_server_and_robot_browser.sh
@@ -1,11 +1,35 @@
 #!/bin/bash
+set -e
 
+REDIRECT_LOGDIR="$HOME/stretch_user/log/web_teleop"
+mkdir -p $REDIRECT_LOGDIR
+STORAGE="localstorage"
+while getopts l:f opt; do
+    case $opt in
+        l)
+            # Usage: ./start_web_server_and_robot_browser.sh -l /tmp/some_folder
+            if [[ -d $OPTARG ]]; then
+                REDIRECT_LOGDIR=$OPTARG
+            fi
+            ;;
+        f)
+            # Usage: ./start_web_server_and_robot_browser.sh -f
+            echo "Using firebase..."
+            STORAGE="firebase"
+    esac
+done
+REDIRECT_LOGFILE="$REDIRECT_LOGDIR/start_web_server_and_robot_browser.`date '+%Y%m%d%H%M'`_redirected.txt"
+echo "Arguments:" &>> $REDIRECT_LOGFILE
+echo "-l $REDIRECT_LOGDIR" &>> $REDIRECT_LOGFILE
+echo "-f $STORAGE" &>> $REDIRECT_LOGFILE
+
+echo "Run webpack..."
 export NODE_EXTRA_CA_CERTS="/home/hello-robot/ament_ws/src/stretch_web_teleop/certificates/rootCA.pem"
-cd ~/ament_ws/src/stretch_web_teleop && pm2 start -s npm --name="stretch_web_teleop" -- run localstorage
-cd ~/ament_ws/src/stretch_web_teleop && pm2 start -s server.js --watch
-cd ~/ament_ws/src/stretch_web_teleop && pm2 start -s start_robot_browser.js --watch
-set +x
-echo ""
-echo "Visit the URL(s) below to see the web interface:"
-echo "https://localhost/operator"
-ifconfig | sed -En 's/127.0.0.1//;s/.*inet (addr:)?(([0-9]*\.){3}[0-9]*).*/https:\/\/\2\/operator/p'
+cd ~/ament_ws/src/stretch_web_teleop && pm2 start -s npm --name="stretch_web_teleop" -- run $STORAGE &>> $REDIRECT_LOGFILE
+
+echo "Start local server..."
+cd ~/ament_ws/src/stretch_web_teleop && pm2 start -s server.js --watch &>> $REDIRECT_LOGFILE
+
+echo "Start robot browser..."
+cd ~/ament_ws/src/stretch_web_teleop && pm2 start -s start_robot_browser.js --watch &>> $REDIRECT_LOGFILE
+ifconfig | sed -En 's/127.0.0.1//;s/.*inet (addr:)?(([0-9]*\.){3}[0-9]*).*/https:\/\/\2\/operator/p' &>> $REDIRECT_LOGFILE

--- a/stop_interface.sh
+++ b/stop_interface.sh
@@ -9,8 +9,9 @@
 # but this would not arise if this script properly terminates
 # realsense nodes.
 screen -S "web_teleop_ros" -X stuff '^C'
+local t1=$?
 sleep 3;
-if [[ $? -ne 0 ]]; then
+if [[ $t1 -ne 0 ]]; then
     echo "Using pkill"
     sudo pkill screen
 fi

--- a/stop_interface.sh
+++ b/stop_interface.sh
@@ -9,7 +9,7 @@
 # but this would not arise if this script properly terminates
 # realsense nodes.
 screen -S "web_teleop_ros" -X stuff '^C'
-local t1=$?
+t1=$?
 sleep 3;
 if [[ $t1 -ne 0 ]]; then
     echo "Using pkill"


### PR DESCRIPTION
# Description

This PR improves the launch/stop scripts in this repo, including:

- `launch_interface.sh`
- `start_ros2.sh`
- `start_web_server_and_robot_browser.sh`
- `stop_interface.sh`
- `start_robot_browser.js`

With `launch_interface.sh` it ensures the user always gets either SUCCESS or FAILURE messages, so it's clear whether web teleop succeeded in starting. Additionally, it logs to Stretch's log directory and creates a zip of the logs that can be shared with support if something goes wrong. Lastly, it shows the right URL to the user depending on whether they're running the local or online version of the interface.

With `start_ros2.sh`, it ensures all the ENV VARS are configured and calls CLIs using their absolute paths to ensure they're likely to execute correctly. It exits immediately if any command fails to execute. It also redirects verbose output to Stretch's log directory.

With `start_web_server_and_robot_browser.sh`, it takes in a `-f` flag and launches either the local or online version of the interface accordingly. It exits immediately if any command fails to execute. It also redirects verbose output to Stretch's log directory.

With `stop_interface.sh`, it fixes a bug where `pkill` is never called.

With `start_robot_browser.js`, it removes arguments that are not needed for a firefox headless browser.

# Testing procedure

Checkout this branch, compile the workspace, and follow the README to start the interface. Ensure it succeeds and logs are present in `~/stretch_user/log/web_teleop/<datetime>`

# Future work

https://github.com/hello-robot/stretch_web_teleop/issues/118