### PR TITLE
Fixed Offline Icons for Map Buttons

### DIFF
--- a/src/pages/operator/tsx/basic_components/RadioGroup.tsx
+++ b/src/pages/operator/tsx/basic_components/RadioGroup.tsx
@@ -28,9 +28,7 @@ export const RadioButton = (props: {
                 {props.label}
             </label>
             <div className="modify">
-                {props.functs.Edit && (
-                    <ModeEdit/>
-                )}
+                {props.functs.Edit && <ModeEdit />}
                 {props.functs.Delete && (
                     <Delete
                         className="material-icons"

--- a/src/pages/operator/tsx/basic_components/RadioGroup.tsx
+++ b/src/pages/operator/tsx/basic_components/RadioGroup.tsx
@@ -2,6 +2,8 @@ import React from "react";
 import { className } from "shared/util";
 import "operator/css/RadioGroup.css";
 import { isMobile } from "react-device-detect";
+import Delete from "@mui/icons-material/DeleteOutline";
+import ModeEdit from "@mui/icons-material/ModeEditOutline";
 
 export const RadioButton = (props: {
     label: string;
@@ -27,17 +29,13 @@ export const RadioButton = (props: {
             </label>
             <div className="modify">
                 {props.functs.Edit && (
-                    <span className="material-icons radio-icon">
-                        mode_edit_outline
-                    </span>
+                    <ModeEdit/>
                 )}
                 {props.functs.Delete && (
-                    <span
+                    <Delete
                         className="material-icons"
                         onClick={() => props.functs.Delete!(props.label)}
-                    >
-                        delete_outline
-                    </span>
+                    />
                 )}
             </div>
         </div>

--- a/src/pages/operator/tsx/layout_components/Map.tsx
+++ b/src/pages/operator/tsx/layout_components/Map.tsx
@@ -26,6 +26,9 @@ import { PopupModal } from "../basic_components/PopupModal";
 import { Tooltip } from "operator/tsx/static_components/Tooltip";
 import { isMobile } from "react-device-detect";
 import { RadioFunctions, RadioGroup } from "../basic_components/RadioGroup";
+import PlayCircle from "@mui/icons-material/PlayCircle";
+import Save from "@mui/icons-material/Save";
+import Cancel from "@mui/icons-material/Cancel";
 
 export enum MapFunction {
     GetMap,
@@ -107,7 +110,7 @@ export const Map = (props: CustomizableComponentProps) => {
             return selectGoal;
         };
     }, []);
-
+    
     let mapFn: MapFunctions = {
         GetMap: mapFunctionProvider.provideFunctions(
             MapFunction.GetMap,
@@ -353,7 +356,7 @@ const UnderMapButtons = (props: {
                         }}
                     >
                         <span>Start</span>
-                        <span className="material-icons">play_circle</span>
+                        <PlayCircle />
                     </button>
                 )}
                 {play && (
@@ -365,7 +368,7 @@ const UnderMapButtons = (props: {
                         }}
                     >
                         <span>Cancel</span>
-                        <span className="material-icons">cancel</span>
+                        <Cancel/>
                     </button>
                 )}
                 <button
@@ -380,7 +383,7 @@ const UnderMapButtons = (props: {
                     }}
                 >
                     <span hidden={props.hideLabels}>Save new destination</span>
-                    <span className="material-icons">save</span>
+                    <Save/>
                 </button>
             </div>
             <RadioGroup functs={radioFuncts} />

--- a/src/pages/operator/tsx/layout_components/Map.tsx
+++ b/src/pages/operator/tsx/layout_components/Map.tsx
@@ -110,7 +110,7 @@ export const Map = (props: CustomizableComponentProps) => {
             return selectGoal;
         };
     }, []);
-    
+
     let mapFn: MapFunctions = {
         GetMap: mapFunctionProvider.provideFunctions(
             MapFunction.GetMap,
@@ -368,7 +368,7 @@ const UnderMapButtons = (props: {
                         }}
                     >
                         <span>Cancel</span>
-                        <Cancel/>
+                        <Cancel />
                     </button>
                 )}
                 <button
@@ -383,7 +383,7 @@ const UnderMapButtons = (props: {
                     }}
                 >
                     <span hidden={props.hideLabels}>Save new destination</span>
-                    <Save/>
+                    <Save />
                 </button>
             </div>
             <RadioGroup functs={radioFuncts} />


### PR DESCRIPTION
# Description


![image](https://github.com/user-attachments/assets/0bd403f3-4079-49cc-b6c4-991688fc1aa2)


Icons for the Map buttons appear as text instead of icons (see image above)

# Testing procedure

- `git checkout bugfix/map_offline_icons`
- Launch interface and check that icons appear for the map buttons.

# Before opening a pull request

From the top-level of this repository, run:

- [ ] `pre-commit run --all-files`

# To merge

- [ ] `Squash & Merge`
