### PR TITLE
Check if wifi-connect available

### DIFF
--- a/start_ros2.sh
+++ b/start_ros2.sh
@@ -32,9 +32,14 @@ echo "-m $MAP_ARG" &>> $REDIRECT_LOGFILE
 echo "-t $TTS_ARG" &>> $REDIRECT_LOGFILE
 
 if [[ -z `nmcli -t -f DEVICE c show --active | grep wlo1` ]]; then
-    echo "Not connected to Wifi. Starting Wifi-Connect..."
-    echo "Please connect to $HOSTNAME wifi and provide your home network's credentials"
-    sudo wifi-connect -s $HOSTNAME &>> $REDIRECT_LOGFILE
+    if ! command -v wifi-connect 2>&1 >/dev/null
+    then
+        echo "Not connected to Wifi, but Wifi-Connect CLI is missing. Doing nothing..."
+    else
+        echo "Not connected to Wifi. Starting Wifi-Connect..."
+        echo "Please connect to $HOSTNAME wifi and provide your home network's credentials"
+        sudo wifi-connect -s $HOSTNAME &>> $REDIRECT_LOGFILE
+    fi
 fi
 
 echo "Setup environment..."


### PR DESCRIPTION
# Description

Bugfix PR that adds a check for the `wifi-connect` command, before attempting to use it. If Stretch isn't connected to Wifi and the command isn't available, the robot won't be accessible remotely, but this might be okay for development use.

# To merge

- [ ] `Squash & Merge`
