### PR TITLE
Don't delete camera view when overlaid buttons are moved/deleted

### DIFF
--- a/src/pages/operator/tsx/utils/layout_helpers.tsx
+++ b/src/pages/operator/tsx/utils/layout_helpers.tsx
@@ -137,7 +137,7 @@ function removeChildFromParent(
 ) {
     // Remove the child from the parent
     parent.children.splice(childIdx, 1);
-    
+
     // If it was the last child, also remove the parent. Continue iteratively.
     let i = -2;
     let parentIdx: number;


### PR DESCRIPTION
# Description

Addresses issue https://github.com/hello-robot/stretch_web_teleop/issues/143 by allowing the `CameraView` component parent type to have no children.

# Testing procedure

Checkout `bugfix/customization` and follow these steps in the customization mode:

- Add a button pad on top of a camera view
- Move and/or delete the button pad on the camera view
- Verify that the camera view does not move or get deleted.

# Before opening a pull request

From the top-level of this repository, run:

- [ ] `pre-commit run --all-files`

# To merge

- [ ] `Squash & Merge`
