### PR TITLE
[WIP] Movement Recorder UX Enhancement

### DIFF
--- a/src/pages/operator/css/MovementRecorder.css
+++ b/src/pages/operator/css/MovementRecorder.css
@@ -1,10 +1,3 @@
-#movement-recorder-container {
-    display: flex;
-    gap: 15px;
-    align-items: center;
-    justify-content: center;
-}
-
 /* The below buttons' CSS likely gets overridden by the TextToSpeech CSS
  * for the same class names. It is not an issue now because they use the
  * same styles, but may be an issue in the future if we change styles for
@@ -56,4 +49,304 @@
     vertical-align: middle;
     display: flex;
     justify-content: center;
+}
+
+
+
+/**********
+ * New UX *
+ **********/
+
+#movement-recorder-container {
+    position: relative;
+    align-self: flex-start;
+    height: 100%;
+    --footer-height: 60px;
+}
+
+
+.pulse {
+    animation: pulse-red-bg 2s infinite;
+}
+
+@keyframes pulse-red-bg {
+    0% {
+        background-color: #fa7878;
+    }
+
+    50% {
+        background-color: #ff0000;
+    }
+
+    100% {
+        background-color: #fa7878;
+    }
+}
+
+.recordings-list {
+    position: relative;
+    overflow-y: scroll;
+    overflow-x: hidden;
+    padding: 8px 0;
+    height: calc(100% - var(--footer-height));
+}
+
+.recordings-list .recording-item {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+    padding: 18px 10px;
+}
+
+.recordings-list .helper-text-empty-state {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    gap: 10px;
+    margin: 0 auto;
+    max-width: 200px;
+    height: 100%;
+    font-size: 16px;
+    font-weight: 600;
+    text-align: center;
+    line-height: 130%;
+    opacity: 0.5;
+}
+
+#movement-recorder-container .footer {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 5px;
+    width: 100%;
+    height: var(--footer-height);
+    background: #ffffff;
+    border-top: 1px solid #000000;
+}
+
+#movement-recorder-container .footer button.button-record {
+    font-weight: 600;
+}
+
+#movement-recorder-container .footer button.button-record.button-record-record svg {
+    color: #ff0000;
+}
+
+#movement-recorder-container .footer button.button-record.button-record-start:disabled svg {
+    color: rgba(16, 16, 16, 0.3);
+}
+
+#movement-recorder-container .footer button.button-record.button-record-start svg {
+    color: #ff0000;
+}
+
+#movement-recorder-container .footer button.button-record.button-record-stop svg {
+    color: #ff0000;
+}
+
+.naming-modal input,
+.footer input {
+    display: flex;
+    width: calc(100% - 20px);
+    padding: 12px 9px;
+}
+
+.footer button.button-cancel,
+.footer button.button-filter,
+.footer .button-scroll-wrapper button.button-scroll {
+    width: 50px;
+}
+
+.joints-list {
+    position: absolute;
+    top: 0;
+    left: 0;
+    padding: 20px;
+    width: 100%;
+    height: calc(100% - var(--footer-height));
+    overflow-y: scroll;
+    overflow-x: hidden;
+    background-color: #ffffff;
+}
+
+.joints-list ul.checkbox {
+    margin: 10px 0 0 0;
+}
+
+.joints-list ul.checkbox.nested {
+    padding: 0 0 0 29px;
+    margin: 0px;
+}
+
+.joints-list ul.checkbox label {
+    top: -6px;
+    position: relative;
+    padding: 10px 0;
+}
+
+.naming-modal {
+    position: absolute;
+    top: 0;
+    left: 0;
+    padding: 20px;
+    width: 100%;
+    height: 100%;
+    background-color: #ffffff;
+}
+
+.joints-list .heading,
+.naming-modal .heading {
+    font-weight: 600;
+    font-size: 18px;
+}
+
+.joints-list .subheading {
+    margin: 7px 0 0;
+    max-width: 227px;
+    font-size: 14px;
+    font-weight: 400;
+    line-height: 133%;
+}
+
+.joints-list button.button-select-all {
+    margin: 15px 0 5px;
+    width: 100%;
+    font-weight: 600;
+}
+
+.naming-modal button {
+    height: 100%;
+}
+
+.recording-name-text-area {
+    margin: 0 5px 0 0;
+    padding: 0px 5px;
+    width: fit-content;
+    height: 31px;
+    line-height: 150%;
+    overflow-wrap: break-word;
+    word-wrap: break-word;
+    resize: none;
+    overflow: hidden;
+    border: 1px solid transparent;
+    border-radius: 4px;
+    background-color: #fafafa;
+}
+
+.recording-name-text-area:disabled {
+    color: #000000;
+    user-select: none !important;
+    -webkit-user-select: none !important;
+    -moz-user-select: none !important;
+    -ms-user-select: none !important;
+    pointer-events: none !important;
+    -webkit-touch-callout: none !important;
+}
+
+.recording-name-text-area:focus {
+    background-color: var(--btn-turquoise-ultra-light);
+    border: 1px solid var(--btn-turquoise);
+    outline: none;
+}
+
+.recording-name-text-area::selection {
+    background-color: var(--btn-turquoise-light);
+}
+
+
+.recording-item-buttons {
+    --button-width: 41px;
+    --transition: all 300ms ease-out;
+}
+
+.recording-item-buttons button {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 0px;
+    aspect-ratio: 1 / 1;
+    width: var(--button-width) !important;
+    min-width: var(--button-width) !important;
+    max-width: var(--button-width) !important;
+    transition: var(--transition);
+    color: var(--btn-blue);
+    border-radius: 4px;
+}
+
+.recording-item-buttons .button-delete-recording-wrapper {
+    z-index: 0;
+    position: relative;
+}
+
+.recording-item-buttons button.button-playback,
+.recording-item-buttons button.button-edit {
+    transition: var(--transition);
+}
+
+.recording-item-buttons button.button-playback.visible,
+.recording-item-buttons button.button-edit.visible {
+    opacity: 1;
+}
+
+.recording-item-buttons button.button-playback.hidden,
+.recording-item-buttons button.button-edit.hidden {
+    opacity: 0;
+}
+
+.recording-item-buttons button.button-edit.editing {
+    color: #ffffff;
+    background-color: var(--btn-turquoise);
+    border: 4px solid var(--btn-turquoise);
+}
+
+.button-delete-recording-wrapper button.button-cancel-deletion {
+    z-index: 1;
+    position: absolute;
+    top: 0;
+    left: 0;
+    box-shadow: none;
+}
+
+.recording-item-buttons button.button-cancel-deletion.hidden {
+    transform: translateX(0%);
+    opacity: 0;
+    pointer-events: none;
+}
+
+.recording-item-buttons button.button-cancel-deletion.visible {
+    transform: translateX(calc(-100% - 5px));
+    opacity: 1;
+}
+
+.button-delete-recording-wrapper .helper-text {
+    z-index: 0;
+    position: absolute;
+    top: 0px;
+    left: 0px;
+    transition: var(--transition);
+    color: var(--btn-blue);
+    font-weight: 600;
+    transform: translate(-65px, calc(var(--button-width)));
+    white-space: nowrap;
+    pointer-events: none;
+}
+
+.button-delete-recording-wrapper .helper-text.hidden {
+    opacity: 0;
+}
+
+.button-delete-recording-wrapper .helper-text.visible {
+    transform: translate(-65px, calc(var(--button-width) + 2px));
+    opacity: 1;
+}
+
+.button-delete-recording-wrapper button.button-delete {
+    z-index: 2;
+    position: relative;
+}
+
+.recording-item-buttons button.button-delete.pulse .button-delete-icon {
+    color: #ffffff;
 }

--- a/src/pages/operator/css/Panel.css
+++ b/src/pages/operator/css/Panel.css
@@ -21,6 +21,11 @@
     border: 3px solid var(--btn-blue);
     flex: 1 1 0;
     background-color: var(--background-color);
+    border-radius: 0px 0px var(--radius) var(--radius);
+}
+
+.tabs-content>div {
+    flex: 1;
 }
 
 /* Header *********************************************************************/

--- a/src/pages/operator/tsx/basic_components/Flex.tsx
+++ b/src/pages/operator/tsx/basic_components/Flex.tsx
@@ -1,0 +1,39 @@
+import React from 'react'
+
+interface FlexProps {
+    children: React.ReactNode;
+    direction?: 'row' | 'column';
+    justify?: 'flex-start' | 'flex-end' | 'center' | 'space-between' | 'space-around';
+    align?: 'flex-start' | 'flex-end' | 'center' | 'stretch' | 'baseline';
+    gap?: number | string;
+    style?: React.CSSProperties;
+    className?: string;
+}
+
+function Flex({
+    children,
+    direction = 'row',
+    justify = 'flex-start',
+    align = 'flex-start',
+    gap = 0,
+    style,
+    className,
+}: FlexProps) {
+    return (
+        <div
+            style={{
+                display: 'flex',
+                flexDirection: direction,
+                justifyContent: justify,
+                alignItems: align,
+                gap,
+                ...style
+            }}
+            className={className}
+        >
+            {children}
+        </div>
+    )
+}
+
+export default Flex

--- a/src/pages/operator/tsx/default_layouts/SIMPLE_LAYOUT.tsx
+++ b/src/pages/operator/tsx/default_layouts/SIMPLE_LAYOUT.tsx
@@ -93,13 +93,10 @@ export const BASIC_LAYOUT: LayoutDefinition = {
                     children: [
                         {
                             type: ComponentType.SingleTab,
-                            label: "Safety",
+                            label: "Movement Recorder",
                             children: [
                                 {
-                                    type: ComponentType.RunStopButton,
-                                },
-                                {
-                                    type: ComponentType.BatteryGuage,
+                                    type: ComponentType.MovementRecorder,
                                 },
                             ],
                         },

--- a/src/pages/operator/tsx/function_providers/MovementRecorderFunctionProvider.tsx
+++ b/src/pages/operator/tsx/function_providers/MovementRecorderFunctionProvider.tsx
@@ -53,7 +53,7 @@ export class MovementRecorderFunctionProvider extends FunctionProvider {
                                 if (
                                     Math.abs(
                                         currentPose[key as ValidJoints]! -
-                                            prevPose[key as ValidJoints]!,
+                                        prevPose[key as ValidJoints]!,
                                     ) > 0.025
                                 ) {
                                     // If there is no prevJoint or the current joint moving has changed
@@ -61,9 +61,9 @@ export class MovementRecorderFunctionProvider extends FunctionProvider {
                                         prevJoint = key as ValidJoints;
                                         prevJointDirection = Math.sign(
                                             currentPose[key as ValidJoints] -
-                                                prevPose[
-                                                    prevJoint as ValidJoints
-                                                ],
+                                            prevPose[
+                                            prevJoint as ValidJoints
+                                            ],
                                         );
                                         this.poses.push(currentPose);
                                         return;
@@ -71,7 +71,7 @@ export class MovementRecorderFunctionProvider extends FunctionProvider {
 
                                     currJointDirection = Math.sign(
                                         currentPose[key as ValidJoints] -
-                                            prevPose[prevJoint as ValidJoints],
+                                        prevPose[prevJoint as ValidJoints],
                                     );
 
                                     // If the direction of joint movement has not been changed
@@ -144,6 +144,16 @@ export class MovementRecorderFunctionProvider extends FunctionProvider {
                 return (name: string) => {
                     let recording = this.storageHandler.getRecording(name);
                     FunctionProvider.remoteRobot?.playbackPoses(recording);
+                };
+            case MovementRecorderFunction.RenameRecording:
+                return (recordingID: number, recordingNameNew: string) => {
+                    let recordingNames = this.storageHandler.getRecordingNames();
+                    // Grab poses from old recording
+                    const poses = this.storageHandler.getRecording(recordingNames[recordingID])
+                    // Delete old recording
+                    this.storageHandler.deleteRecording(recordingNames[recordingID]);
+                    // Save with new name
+                    this.storageHandler.savePoseRecording(recordingNameNew, poses);
                 };
             case MovementRecorderFunction.Cancel:
                 return () => FunctionProvider.remoteRobot?.stopTrajectory();

--- a/src/pages/operator/tsx/layout_components/CustomizableComponent.tsx
+++ b/src/pages/operator/tsx/layout_components/CustomizableComponent.tsx
@@ -13,8 +13,7 @@ import { ButtonStateMap } from "../function_providers/ButtonFunctionProvider";
 import { ButtonGrid } from "./ButtonGrid";
 import { VirtualJoystick } from "./VirtualJoystick";
 import { Map } from "./Map";
-import { RunStopButton } from "../static_components/RunStop";
-import { BatteryGuage } from "../static_components/BatteryGauge";
+import { MovementRecorder } from "../layout_components/MovementRecorder";
 
 /** State required for all elements */
 export type SharedState = {
@@ -84,10 +83,8 @@ export const CustomizableComponent = (props: CustomizableComponentProps) => {
             return <VirtualJoystick {...props} />;
         case ComponentType.Map:
             return <Map {...props} />;
-        case ComponentType.RunStopButton:
-            return <RunStopButton {...props} />;
-        case ComponentType.BatteryGuage:
-            return <BatteryGuage {...props} />;
+        case ComponentType.MovementRecorder:
+            return <MovementRecorder {...props} hideLabels={false} />;
         default:
             throw Error(
                 `CustomizableComponent cannot render component of unknown type: ${props.definition.type}\nYou may need to add a case for this component in the switch statement in CustomizableComponent.`

--- a/src/pages/operator/tsx/layout_components/MovementRecorder.tsx
+++ b/src/pages/operator/tsx/layout_components/MovementRecorder.tsx
@@ -1,16 +1,20 @@
-import React, { useEffect, useState } from "react";
-import { PopupModal } from "../basic_components/PopupModal";
+import React, { useMemo, useEffect, useCallback, useState, useRef } from "react";
+import Flex from "../basic_components/Flex";
 import { movementRecorderFunctionProvider } from "operator/tsx/index";
-import { Dropdown } from "../basic_components/Dropdown";
-import { Tooltip } from "../static_components/Tooltip";
 import "operator/css/MovementRecorder.css";
 import "operator/css/basic_components.css";
-import { isMobile } from "react-device-detect";
-import { RadioFunctions, RadioGroup } from "../basic_components/RadioGroup";
 import PlayCircle from "@mui/icons-material/PlayCircle";
-import RadioButtonCheckedIcon from "@mui/icons-material/RadioButtonChecked";
-import DeleteForeverIcon from "@mui/icons-material/DeleteForever";
-import SaveIcon from "@mui/icons-material/Save";
+import DeleteIcon from '@mui/icons-material/Delete';
+import EditIcon from '@mui/icons-material/Edit';
+import StopCircleIcon from '@mui/icons-material/StopCircle';
+import RadioButtonCheckedIcon from '@mui/icons-material/RadioButtonChecked';
+import NotStartedIcon from '@mui/icons-material/NotStarted';
+import SearchIcon from '@mui/icons-material/Search';
+import KeyboardArrowLeftIcon from '@mui/icons-material/KeyboardArrowLeft';
+import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
+import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
+import LocalFloristIcon from '@mui/icons-material/LocalFlorist';
+
 
 /** All the possible button functions */
 export enum MovementRecorderFunction {
@@ -23,6 +27,7 @@ export enum MovementRecorderFunction {
     Cancel,
     DeleteRecordingName,
     LoadRecordingName,
+    RenameRecording,
 }
 
 export interface MovementRecorderFunctions {
@@ -40,7 +45,268 @@ export interface MovementRecorderFunctions {
     SavedRecordingNames: () => string[];
     DeleteRecording: (recordingID: number) => void;
     LoadRecording: (recordingID: number) => void;
+    RenameRecording: (recordingID: number, recordingNameNew: string) => void;
 }
+
+
+
+/****************************
+ * Record/Start/Stop <button> *
+ ****************************/
+
+const ButtonRecord = (props: {
+    showRecordingStartButton: boolean;
+    showRecordingStartButtonSet: React.Dispatch<React.SetStateAction<boolean>>;
+    isRecording: boolean;
+    isRecordingSet: React.Dispatch<React.SetStateAction<boolean>>;
+    isOneJointSelected: boolean;
+    startRecording: () => void;
+    stopRecording: () => void;
+    saveRecording: (name: string) => void;
+    setRecordings: React.Dispatch<React.SetStateAction<string[]>>;
+    deselectAllJoints: () => void;
+    isNamingModalVisibleSet: (arg0: boolean) => void;
+    recordingNameSet: React.Dispatch<React.SetStateAction<string>>;
+}) => {
+    /////////////////////////
+    //// "Record" button ////
+    /////////////////////////
+    if (
+        !props.showRecordingStartButton
+        && !props.isRecording
+    ) {
+        return (
+            <button
+                onPointerDown={() => props.showRecordingStartButtonSet(true)}
+                className="button-record button-record-record"
+            >
+                Record <RadioButtonCheckedIcon />
+            </button>
+        );
+    }
+    //////////////////////// 
+    //// "Start" button ////
+    ////////////////////////
+    else if (
+        props.showRecordingStartButton
+        && !props.isRecording
+    ) {
+        return (
+            <button
+                onPointerDown={props.startRecording}
+                disabled={!props.isOneJointSelected}
+                className="button-record button-record-start"
+            >
+                Start <NotStartedIcon />
+            </button>
+        );
+    }
+    /////////////////////// 
+    //// "Stop" button ////
+    ///////////////////////
+    else if (props.isRecording) {
+        return (
+            <button
+                onPointerDown={() => {
+                    const tempName = new Date().toLocaleString('en-US', {
+                        month: 'numeric',
+                        day: 'numeric',
+                        hour: 'numeric',
+                        minute: '2-digit',
+                        hour12: true
+                    });
+                    props.recordingNameSet(tempName);
+                    props.isNamingModalVisibleSet(true)
+                }}
+                className="button-record button-record-stop"
+            >
+                Stop <StopCircleIcon />
+            </button>
+        );
+    }
+}
+
+const ButtonFilter = (props: {
+    isFilterActivated: boolean;
+    isFilterActivatedSet: React.Dispatch<React.SetStateAction<boolean>>;
+    filterQuery: string;
+    filterQuerySet: React.Dispatch<React.SetStateAction<string>>;
+}) => {
+
+    // Reference to focus the input when filter is activated
+    const refInput = useRef<HTMLInputElement>(null);
+
+    // Effect to focus the input when filter is activated
+    useEffect(() => {
+        if (props.isFilterActivated && refInput.current) {
+            requestAnimationFrame(() => {
+                refInput.current?.focus();
+            });
+        }
+    }, [props.isFilterActivated]);
+
+    if (!props.isFilterActivated) {
+        return (
+            <button
+                onPointerDown={() => {
+                    props.isFilterActivatedSet(!props.isFilterActivated)
+                }}
+                className="button-filter"
+            >
+                <SearchIcon />
+            </button>
+        );
+    } else return (
+        <div>
+            <input
+                ref={refInput}
+                type="text"
+                placeholder="Type to filter..."
+                value={props.filterQuery}
+                onFocus={(e) => e.target.select()}
+                onChange={(e) => props.filterQuerySet(e.target.value)}
+            />
+        </div>
+    );
+}
+
+interface RecordingItemProps {
+    recordingName: string;
+    idxFixed: number;
+    functions: {
+        LoadRecording: (idx: number) => void;
+        RenameRecording: (idx: number, newName: string) => void;
+        DeleteRecording: (idx: number) => void;
+        SavedRecordingNames: () => string[];
+    };
+    setRecordings: React.Dispatch<React.SetStateAction<string[]>>;
+    scrollToTop?: () => void;
+}
+
+const RecordingItem: React.FC<RecordingItemProps> = ({
+    recordingName,
+    idxFixed,
+    functions,
+    setRecordings,
+    scrollToTop,
+}: RecordingItemProps) => {
+    const [valueTextArea, valueTextAreaSet] = useState<string>(recordingName);
+    const refTextArea = useRef<HTMLTextAreaElement>(null);
+    const recordingsRefresh = useCallback(() => {
+        setRecordings(functions.SavedRecordingNames());
+    }, []);
+    const [isEditing, isEditingSet] = useState<boolean>(false);
+    const [isAskingConfirmationBeforeDelete, isAskingConfirmationBeforeDeleteSet] = useState<boolean>(false);
+    // Focus <textarea>, and select value inside <textarea> when focused
+    useEffect(() => {
+        if (isEditing) {
+            requestAnimationFrame(() => {
+                refTextArea.current?.focus();
+                refTextArea.current?.select();
+            });
+        }
+    }, [isEditing]);
+    // Adjust height of the textarea based on its content
+    // This is to account for recording names that are really
+    // long and need to be able to wrap
+    useEffect(() => {
+        const adjustHeight = () => {
+            const domNode = refTextArea.current;
+            if (domNode) {
+                domNode.style.height = '30px';
+                domNode.style.height = domNode.scrollHeight + 'px';
+            }
+        };
+
+        adjustHeight();
+
+        // Also adjust when window resizes
+        window.addEventListener('resize', adjustHeight);
+
+        return () => {
+            window.removeEventListener('resize', adjustHeight);
+        };
+    }, [valueTextArea]);
+    const updateRecordingName = useCallback(() => {
+        if (refTextArea?.current?.value.trim() === recordingName) {
+            isEditingSet(false)
+        } else {
+            const recordingNameNew = refTextArea?.current?.value.trim() || recordingName;
+
+            functions.RenameRecording(idxFixed, recordingNameNew)
+            recordingsRefresh();
+            isEditingSet(false);
+            scrollToTop();
+        }
+    }, [valueTextArea, idxFixed, recordingName])
+    return (
+        <div
+            className="recording-item"
+            key={recordingName}
+        >
+            <textarea
+                ref={refTextArea}
+                className="recording-name-text-area"
+                value={valueTextArea || recordingName}
+                placeholder={recordingName}
+                onChange={(e) => {
+                    valueTextAreaSet(e.target.value)
+                }}
+                disabled={!isEditing}
+                onBlur={updateRecordingName}
+            />
+            <Flex gap={4} className="recording-item-buttons">
+                <button
+                    onPointerDown={() => {
+                        functions.LoadRecording(idxFixed)
+                    }}
+                    className={
+                        `button-playback
+                        ${!isAskingConfirmationBeforeDelete ? "visible" : "hidden"}`
+                    }
+                >
+                    <PlayCircle />
+                </button>
+                <button
+                    onPointerDown={() => {
+                        isEditingSet(true);
+                    }}
+                    className={`
+                        button-edit
+                        ${!isAskingConfirmationBeforeDelete ? "visible" : "hidden"}
+                        ${isEditing ? 'editing' : ''}
+                    `}
+                ><EditIcon className="button-edit-icon" /></button>
+                <Flex className="button-delete-recording-wrapper">
+                    <button
+                        onPointerDown={() => { isAskingConfirmationBeforeDeleteSet(false) }}
+                        disabled={!isAskingConfirmationBeforeDelete}
+                        className={`button-cancel-deletion ${isAskingConfirmationBeforeDelete ? "visible" : "hidden"}`}
+                    >
+                        <KeyboardArrowLeftIcon />
+                    </button>
+                    <div className={`helper-text ${isAskingConfirmationBeforeDelete ? "visible" : "hidden"}`}>Are you sure?</div>
+                    <button
+                        onPointerDown={() => {
+                            if (isAskingConfirmationBeforeDelete) {
+                                functions.DeleteRecording(idxFixed);
+                                recordingsRefresh();
+                            }
+                            else if (!isAskingConfirmationBeforeDelete) {
+                                isAskingConfirmationBeforeDeleteSet(true)
+                            }
+                        }}
+                        className={`button-delete ${isAskingConfirmationBeforeDelete ? " pulse" : " "}`}
+                    >
+                        <DeleteIcon
+                            className="button-delete-icon"
+                        />
+                    </button>
+                </Flex>
+            </Flex>
+        </div>
+    );
+};
 
 export const MovementRecorder = (props: {
     hideLabels: boolean;
@@ -74,348 +340,482 @@ export const MovementRecorder = (props: {
         LoadRecording: movementRecorderFunctionProvider.provideFunctions(
             MovementRecorderFunction.LoadRecording,
         ) as (recordingID: number) => void,
+        RenameRecording: movementRecorderFunctionProvider.provideFunctions(
+            MovementRecorderFunction.RenameRecording,
+        ) as (recordingID: number, recordingNameNew: string) => void,
     };
 
-    let radioFuncts: RadioFunctions = {
-        Delete: movementRecorderFunctionProvider.provideFunctions(
-            MovementRecorderFunction.DeleteRecordingName,
-        ) as (name: string) => void,
-        GetLabels: functions.SavedRecordingNames,
-        SelectedLabel: (label: string) =>
-            setSelectedIdx(functions.SavedRecordingNames().indexOf(label)),
+
+
+    /*******************
+     * Joint selection *
+     *******************/
+    const [head, setHead] = React.useState<boolean>(false);
+    const [arm, setArm] = React.useState<boolean>(false);
+    const [lift, setLift] = React.useState<boolean>(false);
+    const [wristRoll, setWristRoll] = React.useState<boolean>(false);
+    const [wristPitch, setWristPitch] = React.useState<boolean>(false);
+    const [wristYaw, setWristYaw] = React.useState<boolean>(false);
+    const [gripper, setGripper] = React.useState<boolean>(false);
+    const [isOneJointSelected, isOneJointSelectedSet] = React.useState<boolean>(false);
+    const selectAllJoints = useCallback(() => {
+        setHead(true);
+        setArm(true);
+        setLift(true);
+        setWristRoll(true);
+        setWristPitch(true);
+        setWristYaw(true);
+        setGripper(true);
+    }, []);
+    const deselectAllJoints = useCallback(() => {
+        setHead(false);
+        setArm(false);
+        setLift(false);
+        setWristRoll(false);
+        setWristPitch(false);
+        setWristYaw(false);
+        setGripper(false);
+    }, []);
+    // Effect to check if at least one joint is selected
+    useEffect(() => {
+        isOneJointSelectedSet(
+            head
+            || arm
+            || lift
+            || wristRoll
+            || wristPitch
+            || wristYaw
+            || gripper
+        );
+    }, [head, arm, lift, wristRoll, wristPitch, wristYaw, gripper]);
+
+    // For Arm & Lift
+    const armLiftAllChecked = arm && lift;
+    const armLiftNoneChecked = !arm && !lift;
+    const armLiftIndeterminate = !armLiftAllChecked && !armLiftNoneChecked;
+
+    const armLiftRef = useRef<HTMLInputElement>(null);
+    useEffect(() => {
+        if (armLiftRef.current) {
+            armLiftRef.current.indeterminate = armLiftIndeterminate;
+        }
+    }, [armLiftIndeterminate]);
+
+    const handleArmLiftParentChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        setArm(e.target.checked);
+        setLift(e.target.checked);
     };
 
+    // For Wrist & Gripper
+    const wristGripperAllChecked = wristRoll && wristPitch && wristYaw && gripper;
+    const wristGripperNoneChecked = !wristRoll && !wristPitch && !wristYaw && !gripper;
+    const wristGripperIndeterminate = !wristGripperAllChecked && !wristGripperNoneChecked;
+
+    const wristGripperRef = useRef<HTMLInputElement>(null);
+    useEffect(() => {
+        if (wristGripperRef.current) {
+            wristGripperRef.current.indeterminate = wristGripperIndeterminate;
+        }
+    }, [wristGripperIndeterminate]);
+
+    const handleWristGripperParentChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        setWristRoll(e.target.checked);
+        setWristPitch(e.target.checked);
+        setWristYaw(e.target.checked);
+        setGripper(e.target.checked);
+    };
+
+
+
+    /*************
+     * Recording *
+     *************/
     const [recordings, setRecordings] = useState<string[]>(
         functions.SavedRecordingNames(),
     );
-    const [selectedIdx, setSelectedIdx] = React.useState<number>();
-    const [showJointSelectionModal, setShowJointSelectionModal] =
+    const [isRecording, isRecordingSet] = React.useState<boolean>(false);
+    const [showRecordingStartButton, showRecordingStartButtonSet] =
         useState<boolean>(false);
-    const [showSaveRecordingModal, setShowSaveRecordingModal] =
+    const [isNamingModalVisible, isNamingModalVisibleSet] = React.useState<boolean>(false);
+    const [recordingName, recordingNameSet] = React.useState<string>('');
+
+    const startRecording = useCallback(() => {
+        showRecordingStartButtonSet(false)
+        isRecordingSet(true);
+        functions.Record(
+            head,
+            arm,
+            lift,
+            wristRoll,
+            wristPitch,
+            wristYaw,
+            gripper,
+        );
+    }, [head, arm, lift, wristRoll, wristPitch, wristYaw, gripper,]);
+
+
+
+    /*******************************
+     * Filter state & side-effects *
+     *******************************/
+    const [isFilterActivated, isFilterActivatedSet] =
         useState<boolean>(false);
-    const [isRecording, setIsRecording] = React.useState<boolean>(
-        props.isRecording ? props.isRecording : false,
-    );
+    const [filterQuery, filterQuerySet] = useState<string>('');
+    const recordingsFiltered = useMemo(() => {
+        if (!filterQuery) return recordings;
+        const filterQueryLower = filterQuery.toLowerCase().trim();
+        return recordings.filter(recording =>
+            recording.toLowerCase().includes(filterQueryLower)
+        );
+    }, [filterQuery, recordings]);
 
-    const JointSelectionModal = (props: {
-        setShow: (show: boolean) => void;
-        show: boolean;
-        setIsRecording: (isRecording: boolean) => void;
-    }) => {
-        const [head, setHead] = React.useState<boolean>(false);
-        const [arm, setArm] = React.useState<boolean>(false);
-        const [lift, setLift] = React.useState<boolean>(false);
-        const [wristRoll, setWristRoll] = React.useState<boolean>(false);
-        const [wristPitch, setWristPitch] = React.useState<boolean>(false);
-        const [wristYaw, setWristYaw] = React.useState<boolean>(false);
-        const [gripper, setGripper] = React.useState<boolean>(false);
 
-        function handleAccept() {
-            functions.Record(
-                head,
-                arm,
-                lift,
-                wristRoll,
-                wristPitch,
-                wristYaw,
-                gripper,
+
+    /********************************************
+     * Callback to go back to the drawing board *
+     ********************************************/
+    const dumpToInitialState = useCallback(() => {
+        filterQuerySet('');
+        isFilterActivatedSet(false);
+        showRecordingStartButtonSet(false);
+        deselectAllJoints();
+        isRecordingSet(false);
+        functions.StopRecording();
+        isNamingModalVisibleSet(false);
+    }, []);
+
+
+
+    /****************************
+     * Step-scrolling <buttons> *
+     ****************************/
+    // Refs
+    const refRecordingsList = useRef(null);
+    const refJointsList = useRef(null);
+
+    // Track whether we can scroll up/down
+    const [canScrollUp, setCanScrollUp] = useState(false);
+    const [canScrollDown, setCanScrollDown] = useState(false);
+
+    // Current DOM node to scroll
+    const [domNodeScroll, domNodeScrollSet] = useState<HTMLElement | null>(null);
+    useEffect(() => {
+        const domNodeScroll = !showRecordingStartButton && !isRecording
+            ? refRecordingsList.current
+            : refJointsList.current;
+        domNodeScrollSet(domNodeScroll);
+    }, [showRecordingStartButton, isRecording]);
+
+    // Event listeners when scroll and resize
+    useEffect(() => {
+        if (!domNodeScroll) return;
+
+        const handleScroll = () => {
+            setCanScrollUp(domNodeScroll.scrollTop > 0);
+            setCanScrollDown(
+                domNodeScroll.scrollTop + domNodeScroll.clientHeight <
+                domNodeScroll.scrollHeight - 1
             );
-            setHead(false);
-            setArm(false);
-            setLift(false);
-            setWristRoll(false);
-            setWristPitch(false);
-            setWristYaw(false);
-            setGripper(false);
+        };
+
+        // run once on mount
+        handleScroll();
+
+        // listen to both scroll and resize
+        domNodeScroll.addEventListener("scroll", handleScroll);
+        window.addEventListener("resize", handleScroll);
+
+        return () => {
+            domNodeScroll.removeEventListener("scroll", handleScroll);
+            window.removeEventListener("resize", handleScroll);
+        };
+    }, [domNodeScroll, filterQuery, isRecording, showRecordingStartButton, isNamingModalVisible]);
+    const scrollUp = useCallback(() => {
+        if (domNodeScroll) {
+            const scrollDistance = domNodeScroll.clientHeight * 0.9;
+            domNodeScroll.scrollBy({
+                top: -scrollDistance,
+                behavior: "smooth",
+            });
         }
-
-        return (
-            <PopupModal
-                setShow={props.setShow}
-                show={props.show}
-                onAccept={handleAccept}
-                onCancel={() => {
-                    props.setIsRecording(false);
-                    props.setShow(false);
-                    functions.StopRecording();
-                }}
-                id="save-recording-modal"
-                acceptButtonText="Save"
-                size={isMobile ? "small" : "large"}
-                mobile={isMobile}
-            >
-                {/* <label htmlFor="new-recoding-name"><b>Save Recording</b></label>
-                <hr/> */}
-                <div className="joint-checkbox">
-                    <label>Select the joints to record:</label>
-                </div>
-                <ul className="checkbox">
-                    <li>
-                        <input
-                            type="checkbox"
-                            id="head"
-                            name="save-head-pose"
-                            value="Head"
-                            defaultChecked={head}
-                            onChange={(e) => setHead(e.target.checked)}
-                        />
-                        <label>Head</label>
-                    </li>
-                    <li>
-                        <input
-                            type="checkbox"
-                            id="arm"
-                            name="save-arm-pose"
-                            value="Arm"
-                            defaultChecked={arm}
-                            onChange={(e) => setArm(e.target.checked)}
-                        />
-                        <label>Arm</label>
-                    </li>
-                    <li>
-                        <input
-                            type="checkbox"
-                            id="lift"
-                            name="save-lift-pose"
-                            value="Lift"
-                            defaultChecked={lift}
-                            onChange={(e) => setLift(e.target.checked)}
-                        />
-                        <label>Lift</label>
-                    </li>
-                    <li>
-                        <input
-                            type="checkbox"
-                            id="wristRoll"
-                            name="save-wrist-roll-pose"
-                            value="Wrist Roll"
-                            defaultChecked={wristRoll}
-                            onChange={(e) => setWristRoll(e.target.checked)}
-                        />
-                        <label>Wrist Roll</label>
-                    </li>
-                    <li>
-                        <input
-                            type="checkbox"
-                            id="wristPitch"
-                            name="save-wrist-pitch-pose"
-                            value="Wrist Pitch"
-                            defaultChecked={wristPitch}
-                            onChange={(e) => setWristPitch(e.target.checked)}
-                        />
-                        <label>Wrist Pitch</label>
-                    </li>
-                    <li>
-                        <input
-                            type="checkbox"
-                            id="wristYaw"
-                            name="save-wrist-yaw-pose"
-                            value="Wrist Yaw"
-                            defaultChecked={wristYaw}
-                            onChange={(e) => setWristYaw(e.target.checked)}
-                        />
-                        <label>Wrist Yaw</label>
-                    </li>
-                    <li>
-                        <input
-                            type="checkbox"
-                            id="gripper"
-                            name="save-gripper-pose"
-                            value="Gripper"
-                            defaultChecked={gripper}
-                            onChange={(e) => setGripper(e.target.checked)}
-                        />
-                        <label>Gripper</label>
-                    </li>
-                </ul>
-            </PopupModal>
-        );
-    };
-
-    const SaveRecordingModal = (props: {
-        setShow: (show: boolean) => void;
-        show: boolean;
-    }) => {
-        const [name, setName] = React.useState<string>("");
-        function handleAccept() {
-            if (name.length > 0) {
-                if (!recordings.includes(name)) {
-                    setRecordings((recordings) => [...recordings, name]);
-                }
-                functions.SaveRecording(name);
-            }
-            setName("");
+    }, [domNodeScroll]);
+    const scrollDown = useCallback(() => {
+        if (domNodeScroll) {
+            const scrollDistance = domNodeScroll.clientHeight * 0.9;
+            domNodeScroll.scrollBy({
+                top: scrollDistance,
+                behavior: "smooth",
+            });
         }
+    }, [domNodeScroll]);
+    const scrollToTop = useCallback(() => {
+        domNodeScroll.scrollTo({
+            top: 0,
+            behavior: "smooth",
+        });
+    }, [domNodeScroll]);
 
-        return (
-            <PopupModal
-                setShow={props.setShow}
-                show={props.show}
-                onAccept={handleAccept}
-                onCancel={() => functions.StopRecording()}
-                id="save-recording-modal"
-                acceptButtonText="Save"
-                acceptDisabled={name.length < 1}
-                size={isMobile ? "small" : "large"}
-                mobile={isMobile}
-            >
-                {/* <label htmlFor="new-recoding-name"><b>Save Recording</b></label>
-                <hr/> */}
-                <div className="recording-name">
-                    {/* <label>Recording Name</label> */}
-                    <input
-                        autoFocus
-                        type="text"
-                        id="new-recording-name"
-                        name="new-option-name"
-                        value={name}
-                        onChange={(e) => setName(e.target.value)}
-                        placeholder="Enter name of movement"
-                    />
-                </div>
-            </PopupModal>
-        );
-    };
 
-    // useEffect(() => {
-    //     if (props.isRecording == undefined) {
-    //         return;
-    //     } else if (props.isRecording) {
-    //         functions.Record();
-    //     } else {
-    //         setShowSaveRecordingModal(true);
-    //     }
-    // }, [props.isRecording]);
 
-    if (props.globalRecord !== undefined && !props.globalRecord)
-        return (
-            <SaveRecordingModal
-                setShow={setShowSaveRecordingModal}
-                show={showSaveRecordingModal}
-            />
-        );
+    /****************
+     * Naming Modal *
+     ****************/
+    // ref for <input>
+    const refInputRecordingName = useRef<HTMLInputElement>(null);
 
-    return !isMobile ? (
+    // Auto-select text inside of <input>
+    // when naming modal is visible
+    useEffect(() => {
+        if (isNamingModalVisible) {
+            requestAnimationFrame(() => { refInputRecordingName.current.select() });
+        }
+    }, [isNamingModalVisible]);
+
+
+    return (
         <React.Fragment>
-            <div id="movement-recorder-container">Movement Recorder</div>
             <div id="movement-recorder-container">
-                <Dropdown
-                    onChange={setSelectedIdx}
-                    selectedIndex={selectedIdx}
-                    possibleOptions={recordings}
-                    placeholderText="Select a recording..."
-                    placement="bottom"
-                />
-                <Tooltip text="Play movement" position="top">
-                    <button
-                        className="play-btn btn-label"
-                        onClick={() => {
-                            if (selectedIdx != undefined) {
-                                functions.LoadRecording(selectedIdx);
-                            }
-                        }}
-                    >
-                        <span hidden={props.hideLabels}>Play</span>
-                        <PlayCircle />
-                    </button>
-                </Tooltip>
-                <Tooltip
-                    text={!isRecording ? "Record movement" : "Save movement"}
-                    position="top"
-                >
-                    <button
-                        className="save-btn btn-label"
-                        onClick={() => {
-                            if (!isRecording) {
-                                setIsRecording(true);
-                                setShowJointSelectionModal(true);
-                            } else {
-                                setIsRecording(false);
-                                setShowSaveRecordingModal(true);
-                            }
-                        }}
-                    >
-                        {!isRecording ? (
-                            <i hidden={props.hideLabels}>Record</i>
-                        ) : (
-                            <i hidden={props.hideLabels}>Save</i>
-                        )}
-                        {!isRecording ? (
-                            <RadioButtonCheckedIcon />
-                        ) : (
-                            <SaveIcon />
-                        )}
-                    </button>
-                </Tooltip>
-                <Tooltip text="Delete recording" position="top">
-                    <button
-                        className="delete-btn btn-label"
-                        onClick={() => {
-                            if (selectedIdx != undefined) {
-                                functions.DeleteRecording(selectedIdx);
-                            }
-                            setRecordings(functions.SavedRecordingNames());
-                            setSelectedIdx(undefined);
-                        }}
-                    >
-                        <span hidden={props.hideLabels}>Delete</span>
-                        <DeleteForeverIcon />
-                    </button>
-                </Tooltip>
-            </div>
-            <JointSelectionModal
-                setShow={setShowJointSelectionModal}
-                show={showJointSelectionModal}
-                setIsRecording={setIsRecording}
-            />
-            <SaveRecordingModal
-                setShow={setShowSaveRecordingModal}
-                show={showSaveRecordingModal}
-            />
-        </React.Fragment>
-    ) : (
-        <React.Fragment>
-            <RadioGroup functs={radioFuncts} />
-            <div className="global-btns">
-                {/* <div className="mobile-movement-save-btn" onClick={() => {
-                        if (!isRecording) {
-                            setIsRecording(true)
-                            functions.Record()
-                            if (props.onRecordingChange) props.onRecordingChange(true)
-                        } else {
-                            setIsRecording(false)
-                            setShowSaveRecordingModal(true)
-                            if (props.onRecordingChange) props.onRecordingChange(false)
-                        }
+                <div ref={refRecordingsList} className="recordings-list">
+                    {recordings.length === 0
+                        ? (
+                            <div className="helper-text-empty-state">
+                                <div><LocalFloristIcon fontSize="large" /></div>
+                                <div>You haven't made any recordings yet.</div>
+                            </div>
+                        )
+                        : recordingsFiltered.length
+                            // sort by newest recordings...
+                            ? [...recordingsFiltered].reverse().map((recordingName, idx) => {
+                                const idxFixed = recordings.indexOf(recordingName);
+                                return (
+                                    <RecordingItem
+                                        key={recordingName + idx}
+                                        recordingName={recordingName}
+                                        idxFixed={idxFixed}
+                                        functions={functions}
+                                        setRecordings={setRecordings}
+                                        scrollToTop={scrollToTop}
+                                    />
+                                );
+                            })
+                            : (
+                                <div className="helper-text-empty-state">
+                                    <div><SearchIcon fontSize="large" /></div>
+                                    <div>No recordings</div>
+                                </div>
+                            )
                     }
-                }>
-                    {!isRecording
-                        ? <span className="material-icons">radio_button_checked</span>
-                        : <span className="material-icons">save</span>
-                    }
-                    {!isRecording ? <i>Record</i> : <i>Save</i> }
-                </div> */}
-                <div
-                    className="mobile-movement-play-btn"
-                    onClick={() => {
-                        if (selectedIdx != undefined && selectedIdx > -1) {
-                            functions.LoadRecording(selectedIdx);
-                        }
-                    }}
-                >
-                    <PlayCircle />
-                    <i>Play</i>
+
                 </div>
+                {showRecordingStartButton || isRecording
+                    ? (
+                        <div className="joints-list" ref={refJointsList}>
+                            <div className="heading">Select Joints to Record</div>
+                            <div className="subheading">At least 1 joint needs to be selected to begin recording</div>
+                            <Flex>
+                                <button
+                                    onPointerDown={!isOneJointSelected ? selectAllJoints : deselectAllJoints}
+                                    disabled={isRecording}
+                                    className="button-select-all"
+                                >
+                                    {!isOneJointSelected ? "Select All" : "Deselect All"}
+                                </button>
+                            </Flex>
+                            <ul className="checkbox">
+                                <li>
+                                    <input
+                                        type="checkbox"
+                                        id="head"
+                                        name="save-head-pose"
+                                        value="Head"
+                                        checked={head}
+                                        onChange={(e) => setHead(e.target.checked)}
+                                        disabled={isRecording}
+                                    />
+                                    <label htmlFor="head">Head</label>
+                                </li>
+                                <li>
+                                    <input
+                                        type="checkbox"
+                                        id="arm-lift"
+                                        ref={armLiftRef}
+                                        checked={armLiftAllChecked}
+                                        onChange={handleArmLiftParentChange}
+                                        disabled={isRecording}
+                                    />
+                                    <label htmlFor="arm-lift">Arm & Lift</label>
+                                    <ul className="checkbox nested">
+                                        <li>
+                                            <input
+                                                type="checkbox"
+                                                id="arm"
+                                                name="save-arm-pose"
+                                                value="Arm"
+                                                checked={arm}
+                                                onChange={(e) => setArm(e.target.checked)}
+                                                disabled={isRecording}
+                                            />
+                                            <label htmlFor="arm">Arm</label>
+                                        </li>
+                                        <li>
+                                            <input
+                                                type="checkbox"
+                                                id="lift"
+                                                name="save-lift-pose"
+                                                value="Lift"
+                                                checked={lift}
+                                                onChange={(e) => setLift(e.target.checked)}
+                                                disabled={isRecording}
+                                            />
+                                            <label htmlFor="lift">Lift</label>
+                                        </li>
+                                    </ul>
+                                </li>
+                                <li>
+                                    <input
+                                        type="checkbox"
+                                        id="wrist-gripper"
+                                        ref={wristGripperRef}
+                                        checked={wristGripperAllChecked}
+                                        onChange={handleWristGripperParentChange}
+                                        disabled={isRecording}
+                                    />
+                                    <label htmlFor="wrist-gripper">Wrist & Gripper</label>
+                                    <ul className="checkbox nested">
+                                        <li>
+                                            <input
+                                                type="checkbox"
+                                                id="wristRoll"
+                                                name="save-wrist-roll-pose"
+                                                value="Wrist Roll"
+                                                checked={wristRoll}
+                                                onChange={(e) => setWristRoll(e.target.checked)}
+                                                disabled={isRecording}
+                                            />
+                                            <label htmlFor="wristRoll">Wrist Twist</label>
+                                        </li>
+                                        <li>
+                                            <input
+                                                type="checkbox"
+                                                id="wristPitch"
+                                                name="save-wrist-pitch-pose"
+                                                value="Wrist Pitch"
+                                                checked={wristPitch}
+                                                onChange={(e) => setWristPitch(e.target.checked)}
+                                                disabled={isRecording}
+                                            />
+                                            <label htmlFor="wristPitch">Wrist Bend</label>
+                                        </li>
+                                        <li>
+                                            <input
+                                                type="checkbox"
+                                                id="wristYaw"
+                                                name="save-wrist-yaw-pose"
+                                                value="Wrist Yaw"
+                                                checked={wristYaw}
+                                                onChange={(e) => setWristYaw(e.target.checked)}
+                                                disabled={isRecording}
+                                            />
+                                            <label htmlFor="wristYaw">Wrist Rotate</label>
+                                        </li>
+                                        <li>
+                                            <input
+                                                type="checkbox"
+                                                id="gripper"
+                                                name="save-gripper-pose"
+                                                value="Gripper"
+                                                checked={gripper}
+                                                onChange={(e) => setGripper(e.target.checked)}
+                                                disabled={isRecording}
+                                            />
+                                            <label htmlFor="gripper">Gripper</label>
+                                        </li>
+                                    </ul>
+                                </li>
+                            </ul>
+                        </div>
+                    )
+                    : null}
+
+                {isNamingModalVisible
+                    ? (
+                        <Flex className="naming-modal" direction="column" gap={10}>
+                            <div className="heading">Recording Name</div>
+                            <Flex style={{ width: '100%' }}>
+                                <input
+                                    type="text"
+                                    ref={refInputRecordingName}
+                                    value={recordingName}
+                                    onFocus={(e) => e.target.select()}
+                                    onChange={(e) => recordingNameSet(e.target.value)}
+                                />
+                            </Flex>
+                            <Flex gap={5}>
+                                <button
+                                    onPointerDown={() => {
+                                        setRecordings((recordings) => [...recordings, recordingName]);
+                                        functions.SaveRecording(recordingName);
+                                        showRecordingStartButtonSet(false)
+                                        isRecordingSet(false);
+                                        deselectAllJoints();
+                                        isNamingModalVisibleSet(false);
+                                    }}
+                                    disabled={recordingName.length < 1 || recordings.includes(recordingName)}
+                                >
+                                    <NotStartedIcon /> Save Recording
+                                </button>
+                                <button
+                                    onPointerDown={dumpToInitialState}
+                                >
+                                    Cancel
+                                </button>
+                            </Flex>
+                        </Flex>
+                    )
+                    : null}
+
+                {/* Footer */}
+                {!isNamingModalVisible
+                    ? (<div className="footer">
+                        <Flex gap={5} align="center">
+                            {!isFilterActivated
+                                ? <ButtonRecord
+                                    showRecordingStartButton={showRecordingStartButton}
+                                    showRecordingStartButtonSet={showRecordingStartButtonSet}
+                                    isRecording={isRecording}
+                                    isRecordingSet={isRecordingSet}
+                                    isOneJointSelected={isOneJointSelected}
+                                    startRecording={startRecording}
+                                    stopRecording={functions.StopRecording}
+                                    saveRecording={functions.SaveRecording}
+                                    setRecordings={setRecordings}
+                                    deselectAllJoints={deselectAllJoints}
+                                    isNamingModalVisibleSet={isNamingModalVisibleSet}
+                                    recordingNameSet={recordingNameSet}
+                                />
+                                : null
+                            }
+                            {isFilterActivated || showRecordingStartButton || (isRecording && showRecordingStartButton)
+                                ? <button className="button-cancel" onPointerDown={dumpToInitialState}><KeyboardArrowLeftIcon /></button>
+                                : null
+                            }
+                            {recordings.length && !showRecordingStartButton && !isRecording
+                                ? <ButtonFilter
+                                    isFilterActivated={isFilterActivated}
+                                    isFilterActivatedSet={isFilterActivatedSet}
+                                    filterQuery={filterQuery}
+                                    filterQuerySet={filterQuerySet}
+                                />
+                                : null}
+                        </Flex>
+                        <Flex gap={5} align="center" className="button-scroll-wrapper">
+                            <button className="button-scroll" onPointerDown={scrollUp} disabled={!canScrollUp}><KeyboardArrowUpIcon /></button>
+                            <button className="button-scroll" onPointerDown={scrollDown} disabled={!canScrollDown}><KeyboardArrowDownIcon /></button>
+                        </Flex>
+                    </div>
+                    )
+                    : null}
             </div>
-            <JointSelectionModal
-                setShow={setShowJointSelectionModal}
-                show={showJointSelectionModal}
-                setIsRecording={setIsRecording}
-            />
-            <SaveRecordingModal
-                setShow={setShowSaveRecordingModal}
-                show={showSaveRecordingModal}
-            />
         </React.Fragment>
     );
 };

--- a/src/pages/operator/tsx/layout_components/Panel.tsx
+++ b/src/pages/operator/tsx/layout_components/Panel.tsx
@@ -55,8 +55,8 @@ export const Panel = (props: CustomizableComponentProps) => {
 
     // Should take up screen size proportional to number of children
     const flex =
-        activeTabDef.label === "Safety"
-            ? 1
+        activeTabDef.label === "Movement Recorder"
+            ? 1.5
             : Math.max(activeTabDef.children.length + 1, 1);
 
     /** Props for rendering the children elements inside the active tab */

--- a/src/pages/operator/tsx/static_components/Sidebar.tsx
+++ b/src/pages/operator/tsx/static_components/Sidebar.tsx
@@ -109,10 +109,6 @@ function componentDescription(definition: ComponentDefinition): string {
 
 /** Properties for {@link SidebarGlobalOptions} */
 export type GlobalOptionsProps = {
-    /** If the save/load poses should be displayed. */
-    displayMovementRecorder: boolean;
-    setDisplayMovementRecorder: (displayMovementRecorder: boolean) => void;
-
     /** If the text-to-speech component should be displayed */
     displayTextToSpeech: boolean;
     setDisplayTextToSpeech: (displayTextToSpeech: boolean) => void;
@@ -153,15 +149,6 @@ const SidebarGlobalOptions = (props: GlobalOptionsProps) => {
                     on={!props.displayLabels}
                     onClick={() => props.setDisplayLabels(!props.displayLabels)}
                     label="Display button text labels"
-                />
-                <OnOffToggleButton
-                    on={!props.displayMovementRecorder}
-                    onClick={() =>
-                        props.setDisplayMovementRecorder(
-                            !props.displayMovementRecorder,
-                        )
-                    }
-                    label="Display movement recorder"
                 />
                 <OnOffToggleButton
                     on={!props.displayTextToSpeech}

--- a/src/pages/operator/tsx/utils/component_definitions.tsx
+++ b/src/pages/operator/tsx/utils/component_definitions.tsx
@@ -25,6 +25,7 @@ export enum ComponentType {
     Map = "Map",
     RunStopButton = "Run Stop Button",
     BatteryGuage = "Battery Gauge",
+    MovementRecorder = "Movement Recorder",
 }
 
 /**


### PR DESCRIPTION
# Description

Previously movement recorder was a global setting. When enabled in the Customization mode, the movement recorder would appear as a widget between the header and the panels. This took up significant vertical space on smaller screens. In this feature enhancement, movement recorder appears in a panel below the control buttons in the default view and has additional functionality that allows the user to edit and filter through a list of recorded movements.

# Testing procedure

Checkout the `feature/move_r_contained` branch and launch the interface. As the default layout has changed, you may need to run `localStorage.clear()` in the webpage console. Movement recorder should appear below the controls similar to below:
![image](https://github.com/user-attachments/assets/b8b9d5da-6c20-46b4-a460-5403fd918de0)

Test the following behaviors:
- [ ] Save a specific pose
- [ ] Save a sequences of movements
- [ ] Edit a saved recording
- [ ] Delete a saved recording
- [ ] Search through a list of saved recordings 

TO DOs:
- [ ] Add an option in the sidebar to hide the entire movement recorder panel
- [ ] The user should not be able to add a tab to the movement recorder panel, or move the movement recorder tab to another panel. The only customization option should be to move the movement recorder panel elsewhere.
- [ ] Maintain the state when a recording is being played, allow it to be canceled. User should not be able to play another recording while another is being played.

# Before opening a pull request

From the top-level of this repository, run:

- [ ] `pre-commit run --all-files`

# To merge

- [ ] `Squash & Merge`
